### PR TITLE
Fix test build error

### DIFF
--- a/stellarsdk/stellarsdkTests/effects/EffectsLocalTestCase.swift
+++ b/stellarsdk/stellarsdkTests/effects/EffectsLocalTestCase.swift
@@ -673,7 +673,6 @@ class EffectsLocalTestCase: XCTestCase {
             XCTAssertNotNil(effectResponse.links.precedes)
             XCTAssertEqual(effectResponse.links.precedes.href, "http://horizon-testnet.stellar.org/effects?order=asc&cursor=33788507721730-2")
             XCTAssertNil(effectResponse.links.precedes.templated)
-            
         }
         
         wait(for: [expectation], timeout: 15.0)

--- a/stellarsdk/stellarsdkTests/effects/EffectsLocalTestCase.swift
+++ b/stellarsdk/stellarsdkTests/effects/EffectsLocalTestCase.swift
@@ -180,6 +180,12 @@ class EffectsLocalTestCase: XCTestCase {
                         } else {
                             XCTAssert(false)
                         }
+                    case .accountInflationDestinationUpdated:
+                        if record is AccountInflationDestinationUpdatedEffectResponse {
+                            validateAccountInflationDestinationUpdatedEffectResponse(effectResponse: record as! AccountInflationDestinationUpdatedEffectResponse)
+                        } else {
+                            XCTAssert(false)
+                        }
                 }
             }
         }
@@ -652,6 +658,22 @@ class EffectsLocalTestCase: XCTestCase {
             XCTAssertEqual(effectResponse.boughtAssetType, AssetTypeAsString.CREDIT_ALPHANUM12)
             XCTAssertEqual(effectResponse.boughtAssetCode, "TESTTEST")
             XCTAssertEqual(effectResponse.boughtAssetIssuer, "GAHXPUDP3AK6F2QQM4FIRBGPNGKLRDDSTQCVKEXXKKRHJZUUQ23D5BU7")
+        }
+        
+        func validateAccountInflationDestinationUpdatedEffectResponse(effectResponse: AccountInflationDestinationUpdatedEffectResponse) {
+            XCTAssertNotNil(effectResponse.links)
+            XCTAssertNotNil(effectResponse.links.operation)
+            XCTAssertEqual(effectResponse.links.operation.href, "http://horizon-testnet.stellar.org/operations/33788507721730")
+            XCTAssertNil(effectResponse.links.operation.templated)
+            
+            XCTAssertNotNil(effectResponse.links.succeeds)
+            XCTAssertEqual(effectResponse.links.succeeds.href, "http://horizon-testnet.stellar.org/effects?order=desc&cursor=33788507721730-2")
+            XCTAssertNil(effectResponse.links.succeeds.templated)
+            
+            XCTAssertNotNil(effectResponse.links.precedes)
+            XCTAssertEqual(effectResponse.links.precedes.href, "http://horizon-testnet.stellar.org/effects?order=asc&cursor=33788507721730-2")
+            XCTAssertNil(effectResponse.links.precedes.templated)
+            
         }
         
         wait(for: [expectation], timeout: 15.0)

--- a/stellarsdk/stellarsdkTests/offers/OffersLocalTestCase.swift
+++ b/stellarsdk/stellarsdkTests/offers/OffersLocalTestCase.swift
@@ -76,7 +76,7 @@ class OffersLocalTestCase: XCTestCase {
                 XCTAssertEqual(offer.links.seller.href, "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4")
                 XCTAssertNil(offer.links.seller.templated)
                 
-                XCTAssertEqual(offer.id, "121")
+                XCTAssertEqual(offer.id, 121)
                 XCTAssertEqual(offer.pagingToken, "121")
                 XCTAssertEqual(offer.seller, "GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4")
                 XCTAssertEqual(offer.selling.assetType, AssetTypeAsString.CREDIT_ALPHANUM4)

--- a/stellarsdk/stellarsdkTests/trades/TradesTestCase.swift
+++ b/stellarsdk/stellarsdkTests/trades/TradesTestCase.swift
@@ -92,7 +92,7 @@ class TradesTestCase: XCTestCase {
         sdk.trades.getTrades(forAccount: testSuccessAccountId, from: nil, order: nil, limit: nil) { (response) -> (Void) in
             switch response {
             case .success(let tradesResponse):
-                XCTAssertTrue(Response.records.count > 0)
+                XCTAssertTrue(tradesResponse.records.count > 0)
                 XCTAssert(true)
             case .failure(let error):
                 StellarSDKLog.printHorizonRequestErrorMessage(tag:"GT Test", horizonRequestError: error)


### PR DESCRIPTION
The unit tests are failing on build because of compile errors in the following three files:

1. EffectsLocalTestCase.swift
Switch statement must be exhaustive and case for `.accountInflationDestinationUpdated` was missing.

2. OffersLocalTestCase.swift
`id` of `OfferResponse` should be Int type but it was comparing to a string.

3. TradesTestCase.swift
It's a typo I guess. It should access to `records` of `tradesResponse`, not `Response`.


I checked there is no more build error after fixing them 😄 