### PR TITLE
[FIX] Runtime exception when passing Int larger than Int32 into Price.toXdr()

### DIFF
--- a/stellarsdk/stellarsdk/errors/StellarSDKError.swift
+++ b/stellarsdk/stellarsdk/errors/StellarSDKError.swift
@@ -14,6 +14,4 @@ public enum StellarSDKError: Error {
     case xdrEncodingError(message: String)
     case encodingError(message: String)
     case decodingError(message: String)
-    case xdrPriceNumeratorOverflow(message: String)
-    case xdrPriceDenominatorOverflow(message: String)
 }

--- a/stellarsdk/stellarsdk/errors/StellarSDKError.swift
+++ b/stellarsdk/stellarsdk/errors/StellarSDKError.swift
@@ -14,4 +14,6 @@ public enum StellarSDKError: Error {
     case xdrEncodingError(message: String)
     case encodingError(message: String)
     case decodingError(message: String)
+    case xdrPriceNumeratorOverflow(message: String)
+    case xdrPriceDenominatorOverflow(message: String)
 }

--- a/stellarsdk/stellarsdk/sdk/CreatePassiveOfferOperation.swift
+++ b/stellarsdk/stellarsdk/sdk/CreatePassiveOfferOperation.swift
@@ -49,7 +49,7 @@ public class CreatePassiveOfferOperation:Operation {
         let sellingXDR = try selling.toXDR()
         let buyingXDR = try buying.toXDR()
         let amountXDR = Operation.toXDRAmount(amount: amount)
-        let priceXDR = price.toXdr()
+        let priceXDR = try price.toXdr()
         
         return OperationBodyXDR.createPassiveOffer(CreatePassiveOfferOperationXDR(selling: sellingXDR,
                                                                                   buying: buyingXDR,

--- a/stellarsdk/stellarsdk/sdk/CreatePassiveOfferOperation.swift
+++ b/stellarsdk/stellarsdk/sdk/CreatePassiveOfferOperation.swift
@@ -41,7 +41,7 @@ public class CreatePassiveOfferOperation:Operation {
         self.selling = try! Asset.fromXDR(assetXDR: fromXDR.selling)
         self.buying = try! Asset.fromXDR(assetXDR: fromXDR.buying)
         self.amount = Operation.fromXDRAmount(fromXDR.amount)
-        self.price = Price(numerator: Int(fromXDR.price.n), denominator: Int(fromXDR.price.d))
+        self.price = Price(numerator: fromXDR.price.n, denominator: fromXDR.price.d)
         super.init(sourceAccount: sourceAccount)
     }
     
@@ -49,7 +49,7 @@ public class CreatePassiveOfferOperation:Operation {
         let sellingXDR = try selling.toXDR()
         let buyingXDR = try buying.toXDR()
         let amountXDR = Operation.toXDRAmount(amount: amount)
-        let priceXDR = try price.toXdr()
+        let priceXDR = price.toXdr()
         
         return OperationBodyXDR.createPassiveOffer(CreatePassiveOfferOperationXDR(selling: sellingXDR,
                                                                                   buying: buyingXDR,

--- a/stellarsdk/stellarsdk/sdk/ManageOfferOperation.swift
+++ b/stellarsdk/stellarsdk/sdk/ManageOfferOperation.swift
@@ -44,7 +44,7 @@ public class ManageOfferOperation:Operation {
         self.selling = try! Asset.fromXDR(assetXDR: fromXDR.selling)
         self.buying = try! Asset.fromXDR(assetXDR: fromXDR.buying)
         self.amount = Operation.fromXDRAmount(fromXDR.amount)
-        self.price = Price(numerator: Int(fromXDR.price.n), denominator: Int(fromXDR.price.d))
+        self.price = Price(numerator: fromXDR.price.n, denominator: fromXDR.price.d)
         self.offerId = fromXDR.offerID
         super.init(sourceAccount: sourceAccount)
     }
@@ -53,7 +53,7 @@ public class ManageOfferOperation:Operation {
         let sellingXDR = try selling.toXDR()
         let buyingXDR = try buying.toXDR()
         let amountXDR = Operation.toXDRAmount(amount: amount)
-        let priceXDR = try price.toXdr()
+        let priceXDR = price.toXdr()
         
         return OperationBodyXDR.manageOffer(ManageOfferOperationXDR(selling: sellingXDR,
                                                                     buying: buyingXDR,

--- a/stellarsdk/stellarsdk/sdk/ManageOfferOperation.swift
+++ b/stellarsdk/stellarsdk/sdk/ManageOfferOperation.swift
@@ -53,7 +53,7 @@ public class ManageOfferOperation:Operation {
         let sellingXDR = try selling.toXDR()
         let buyingXDR = try buying.toXDR()
         let amountXDR = Operation.toXDRAmount(amount: amount)
-        let priceXDR = price.toXdr()
+        let priceXDR = try price.toXdr()
         
         return OperationBodyXDR.manageOffer(ManageOfferOperationXDR(selling: sellingXDR,
                                                                     buying: buyingXDR,

--- a/stellarsdk/stellarsdk/sdk/Price.swift
+++ b/stellarsdk/stellarsdk/sdk/Price.swift
@@ -64,7 +64,15 @@ public class Price {
     /// Generates a PriceXDR object from the current Price object.
     ///
     /// - Returns the generated PriceXDR object.
-    public func toXdr() -> PriceXDR {
+    public func toXdr() throws -> PriceXDR {
+        guard n <= Int32.max else {
+            throw StellarSDKError.xdrPriceNumeratorOverflow(message: "value must be below \(Int32.max)")
+        }
+
+        guard d <= Int32.max else {
+            throw StellarSDKError.xdrPriceDenominatorOverflow(message: "value must be below \(Int32.max)")
+        }
+
         return PriceXDR(n: Int32(n), d: Int32(d))
     }
 }

--- a/stellarsdk/stellarsdk/sdk/Price.swift
+++ b/stellarsdk/stellarsdk/sdk/Price.swift
@@ -12,17 +12,17 @@ import Foundation
 public class Price {
     
     /// Numerator.
-    public final let n:Int
+    public final let n:Int32
     
     /// Denominator.
-    public final let d:Int
+    public final let d:Int32
     
     /// Create a new price. Price in Stellar is represented as a fraction. E.g. Price of 1 unit of selling in terms of buying. For example, if you wanted to sell 30 XLM and buy 5 BTC, the price would be {numerator, denominator} = {5,30}.
     ///
     /// - Parameter numerator: numerator
     /// - Parameter denominator: denominator
     ///
-    public init(numerator:Int, denominator:Int) {
+    public init(numerator:Int32, denominator:Int32) {
         self.n = numerator
         self.d = denominator
     }
@@ -57,23 +57,15 @@ public class Price {
         }
         let n = NSDecimalNumber(decimal:fractions.last?.first ?? 0)
         let d = NSDecimalNumber(decimal:fractions.last?.last ?? 0)
-        return Price(numerator: n.intValue, denominator: d.intValue)
+        return Price(numerator: n.int32Value, denominator: d.int32Value)
     }
     
     
     /// Generates a PriceXDR object from the current Price object.
     ///
     /// - Returns the generated PriceXDR object.
-    public func toXdr() throws -> PriceXDR {
-        guard n <= Int32.max else {
-            throw StellarSDKError.xdrPriceNumeratorOverflow(message: "value must be below \(Int32.max)")
-        }
-
-        guard d <= Int32.max else {
-            throw StellarSDKError.xdrPriceDenominatorOverflow(message: "value must be below \(Int32.max)")
-        }
-
-        return PriceXDR(n: Int32(n), d: Int32(d))
+    public func toXdr() -> PriceXDR {
+        return PriceXDR(n: n, d: d)
     }
 }
 

--- a/stellarsdk/stellarsdkTests/price/PriceTestCase.swift
+++ b/stellarsdk/stellarsdkTests/price/PriceTestCase.swift
@@ -33,5 +33,12 @@ class PriceTestCase: XCTestCase {
             XCTAssert(false)
         }
     }
-    
+
+    func testPriceToXdrThrowsWhenConvertingLargeComponents() {
+        let largerThanInt32 = 1000000000000000
+        let bigNumerator = Price(numerator: largerThanInt32, denominator: 10)
+        let bigDenominator = Price(numerator: 10, denominator: largerThanInt32)
+        XCTAssertThrowsError(try bigNumerator.toXdr())
+        XCTAssertThrowsError(try bigDenominator.toXdr())
+    }
 }

--- a/stellarsdk/stellarsdkTests/price/PriceTestCase.swift
+++ b/stellarsdk/stellarsdkTests/price/PriceTestCase.swift
@@ -33,12 +33,4 @@ class PriceTestCase: XCTestCase {
             XCTAssert(false)
         }
     }
-
-    func testPriceToXdrThrowsWhenConvertingLargeComponents() {
-        let largerThanInt32 = 1000000000000000
-        let bigNumerator = Price(numerator: largerThanInt32, denominator: 10)
-        let bigDenominator = Price(numerator: 10, denominator: largerThanInt32)
-        XCTAssertThrowsError(try bigNumerator.toXdr())
-        XCTAssertThrowsError(try bigDenominator.toXdr())
-    }
 }


### PR DESCRIPTION
## Priority
Normal

## Description
When creating a `Price` object, I noticed the mismatched types between parameters for `PriceXDR` and the instance variables for `numerator` and `denominator`. 

I attempted to set `n` and `d` to values larger than `Int32.max` and convert that `Price` object to a `PriceXDR` object using the supplied helper, and sure enough, I encountered a runtime exception.

I corrected this by having the `.toXdr()` method throw an error, and forcing clients to handle it upstream.