### PR TITLE
[FIX] Fixes issue #35 - max length Memo text fails initialization

### DIFF
--- a/stellarsdk/stellarsdk/sdk/Memo.swift
+++ b/stellarsdk/stellarsdk/sdk/Memo.swift
@@ -45,7 +45,7 @@ extension Memo: MemoProtocol {
     /// - Throws an StellarSDKError.invalidArgument error if the given string is larger than 28 bytes.
     ///
     public init?(text:String) throws {
-        if text.utf8CString.count > 28 {
+        if text.count > 28 {
             throw StellarSDKError.invalidArgument(message: "text must be <= 28 bytes. length=\(text.count)" )
         }
         self = .text(text)

--- a/stellarsdk/stellarsdkTests/memo/MemoRemoteTestCase.swift
+++ b/stellarsdk/stellarsdkTests/memo/MemoRemoteTestCase.swift
@@ -133,4 +133,14 @@ class MemoRemoteTestCase: XCTestCase {
         
         wait(for: [expectation], timeout: 30.0)
     }
+
+    func testMaxLengthMemoText() {
+        let failingTestString = "https://gift-fakeurlspam.info"
+        let passingTestString1 = "https://gift-fakeurlspam.org"
+        let passingTestString2 = "https://gift-fakeurlspam.cc"
+
+        XCTAssertNoThrow(try Memo(text: passingTestString1))
+        XCTAssertNoThrow(try Memo(text: passingTestString2))
+        XCTAssertThrowsError(try Memo(text: failingTestString))
+    }
 }


### PR DESCRIPTION
## Priority
Normal

## Description
This PR corrects issues #35 which is caused by a max-length null terminated C-string. It adds tests for the edge case and corrects the issue by making the `text.utf8CString.count` consistent with the method of checking the string length in the thrown exception (`text.count`).

## Related Issues
See #35 