### PR TITLE
[FIX] Decoding ErrorRequest when Horizon optionally returns 'instance' field

### DIFF
--- a/stellarsdk/stellarsdk/responses/error_responses/ErrorResponse.swift
+++ b/stellarsdk/stellarsdk/responses/error_responses/ErrorResponse.swift
@@ -25,7 +25,7 @@ public class ErrorResponse: NSObject, Decodable {
     public var detail:String
     
     /// A token that uniquely identifies this request. Allows server administrators to correlate a client report with server log files.
-    public var instance:String
+    public var instance:String?
     
     // Properties to encode and decode
     private enum CodingKeys: String, CodingKey {
@@ -47,6 +47,6 @@ public class ErrorResponse: NSObject, Decodable {
         title = try values.decode(String.self, forKey: .title)
         httpStatusCode = try values.decode(UInt.self, forKey: .httpStatusCode)
         detail = try values.decode(String.self, forKey: .detail)
-        instance = try values.decode(String.self, forKey: .instance)
+        instance = try values.decodeIfPresent(String.self, forKey: .instance)
     }
 }

--- a/stellarsdk/stellarsdk/utils/StellarSDKLog.swift
+++ b/stellarsdk/stellarsdk/utils/StellarSDKLog.swift
@@ -59,7 +59,7 @@ public final class StellarSDKLog {
         print("\(tag): Horizon Error response tite: \(errorResponse!.title)")
         print("\(tag): Horizon Error response httpStatusCode: \(errorResponse!.httpStatusCode)")
         print("\(tag): Horizon Error response detail: \(errorResponse!.detail)")
-        print("\(tag): Horizon Error response instance: \(errorResponse!.instance)")
+        print("\(tag): Horizon Error response instance: \(errorResponse!.instance ?? "unspecified")")
         
         if let transactionFailedErrorResponse = errorResponse! as? TransactionFailedErrorResponse {
             print("\(tag): Horizon Error response envelope XDR: \(transactionFailedErrorResponse.envelopeXDR)")


### PR DESCRIPTION
## Priority
Normal

## Description
This PR corrects the SDK's ability to decode `ErrorRequest` objects when Horizon doesn't provide an instance field in the response JSON.

In my testing, this JSON key is often excluded when I send malformed requests, causing less-specific error details to be provided when the SDK throws a `badRequest` error.

See related `switch` case: https://github.com/Soneso/stellar-ios-mac-sdk/blob/a9f01dbebac62cb647a27fcaa1c2d6ea8487c5cb/stellarsdk/stellarsdk/service/ServiceHelper.swift#L157

## Notes
This affects the more general case in `ErrorResponse`, and I'm positive this will apply to other errors since they're subclassed from `ErrorResponse`. 

It happens more often that I've constructed a malformed transaction and the server responds with with a `BadRequestError`, so this case is easiest to reproduce.