### PR TITLE
[FIX] Add missing return after reestablishing streaming connection

### DIFF
--- a/stellarsdk/stellarsdk/utils/EventSource.swift
+++ b/stellarsdk/stellarsdk/utils/EventSource.swift
@@ -182,6 +182,7 @@ open class EventSource: NSObject, URLSessionDataDelegate {
             DispatchQueue.main.asyncAfter(deadline: delayTime) {
                 self.connect()
             }
+            return
         }
         
         DispatchQueue.main.async {


### PR DESCRIPTION
## Priority
Low

## Description
The streaming connections are generating a lot of error output when reconnecting after the stream connection is closed. This PR adds a missing return statement that's allowing the error handler to be called even though `self.connect` was being issued.

## Notes
See discussion with @chelemen-razvan in issue #39