### PR TITLE
[FEATURE] Adds support to pass an error in the open callback for EventSource

### DIFF
--- a/stellarsdk/stellarsdk/service/Streaming/StreamingHelper.swift
+++ b/stellarsdk/stellarsdk/service/Streaming/StreamingHelper.swift
@@ -21,8 +21,11 @@ public class StreamingHelper: NSObject {
     func streamFrom(path:String, responseClosure:@escaping StreamResponseEnum<String>.ResponseClosure) {
         let streamingURL = baseURL + path
         eventSource = EventSource(url: streamingURL, headers: ["Accept" : "text/event-stream"])
-        eventSource.onOpen {
-            if !self.closed {
+        eventSource.onOpen { httpResponse in
+            if httpResponse?.statusCode == 404 {
+                let error = HorizonRequestError.notFound(message: "Horizon object missing", horizonErrorResponse: nil)
+                responseClosure(.error(error: error))
+            } else if !self.closed {
                 responseClosure(.open)
             }
         }

--- a/stellarsdk/stellarsdk/utils/EventSource.swift
+++ b/stellarsdk/stellarsdk/utils/EventSource.swift
@@ -20,7 +20,7 @@ open class EventSource: NSObject, URLSessionDataDelegate {
     let url: URL
     fileprivate let lastEventIDKey: String
     fileprivate let receivedString: NSString?
-    fileprivate var onOpenCallback: (() -> Void)?
+    fileprivate var onOpenCallback: ((HTTPURLResponse?) -> Void)?
     fileprivate var onErrorCallback: ((NSError?) -> Void)?
     fileprivate var onMessageCallback: ((_ id: String?, _ event: String?, _ data: String?) -> Void)?
     open internal(set) var readyState: EventSourceState
@@ -110,7 +110,7 @@ open class EventSource: NSObject, URLSessionDataDelegate {
     }
     
     //Mark: EventListeners
-    open func onOpen(_ onOpenCallback: @escaping (() -> Void)) {
+    open func onOpen(_ onOpenCallback: @escaping ((HTTPURLResponse?) -> Void)) {
         self.onOpenCallback = onOpenCallback
     }
     
@@ -164,7 +164,7 @@ open class EventSource: NSObject, URLSessionDataDelegate {
         self.readyState = EventSourceState.open
         if self.onOpenCallback != nil {
             DispatchQueue.main.async {
-                self.onOpenCallback!()
+                self.onOpenCallback!(response as? HTTPURLResponse)
             }
         }
     }

--- a/stellarsdk/stellarsdkTests/operations/xdr/OperationXDRTestCase.swift
+++ b/stellarsdk/stellarsdkTests/operations/xdr/OperationXDRTestCase.swift
@@ -722,7 +722,7 @@ class OperationXDRTestCase: XCTestCase {
             XCTAssertEqual(data, parsedOperation.data)
             
             let base64 = try operation.toXDRBase64()
-            XCTAssertEqual("AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAoAAAAEdGVzdAAAAAEAAAAFAAECAwQAAAA=", base64)
+            XCTAssertEqual("AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAoAAAAEdGVzdAAAAAEAAAAFAAECAwQ=", base64)
             
             expectation.fulfill()
         } catch {


### PR DESCRIPTION
## Priority
Normal

## Description
This corrects some retain cycles caused by dispatching without specifying `weak / unowned` to the dispatched callbacks. Now, when `close()` is called in `StreamingHelper.swift` and the `EventSource` object is set to `nil`, the whole object can be released from memory.

Additionally, if a streamable object doesn't exist in Horizon, the client application has no mechanism that allows it to decide if it wants to keep trying to maintain the streaming connection or not.

This PR also adds support to check for a 404 HTTP status code when attempting to open the stream and passing the error through to the `onOpenCallback` in `EventSource.swift`:

```swift
public func onReceive(response:@escaping StreamResponseEnum<TransactionResponse>.ResponseClosure) {
   ...
}
```

With this change, users of the SDK can now receive an error when using each type of streamable object when that object doesn't exist.

This means clients can choose to call `.closeStream()` for a `TransactionsStreamItem`, a `EffectsStreamItem`, or `OperationsStreamItem`, etc. when they don't exist. 

Being able to react to stream failures is important so the radio on mobile devices isn't being over-utilized, causing excessive battery drain.

## Screenshot
<img width="952" alt="screen shot 2019-01-16 at 3 27 24 pm" src="https://user-images.githubusercontent.com/728690/51276636-3faa4d80-19a3-11e9-8a6e-60184f53e34d.png">
