### PR TITLE
[FIX] Make more streaming event closures avoid retaining parent object

### DIFF
--- a/stellarsdk/stellarsdk/service/Streaming/OperationsStreamItem.swift
+++ b/stellarsdk/stellarsdk/service/Streaming/OperationsStreamItem.swift
@@ -19,20 +19,21 @@ public class OperationsStreamItem: NSObject {
     }
     
     public func onReceive(response:@escaping StreamResponseEnum<OperationResponse>.ResponseClosure) {
-        streamingHelper.streamFrom(path:subpath) { (helperResponse) -> (Void) in
+        streamingHelper.streamFrom(path:subpath) { [weak self] (helperResponse) -> (Void) in
             switch helperResponse {
             case .open:
                 response(.open)
             case .response(let id, let data):
                 do {
                     let jsonData = data.data(using: .utf8)!
-                    let operation = try self.operationsFactory.operationFromData(data: jsonData)
+                    guard let operation = try self?.operationsFactory.operationFromData(data: jsonData) else { return }
                     response(.response(id: id, data: operation))
                 } catch {
                     response(.error(error: HorizonRequestError.parsingResponseFailed(message: error.localizedDescription)))
                 }
             case .error(let error):
-                response(.error(error: HorizonRequestError.errorOnStreamReceive(message: "Error from Horizon on stream with path \(self.subpath): \(error?.localizedDescription ?? "nil")")))
+                let operationSubpath = self?.subpath ?? "unknown"
+                response(.error(error: HorizonRequestError.errorOnStreamReceive(message: "Error from Horizon on stream with path \(operationSubpath): \(error?.localizedDescription ?? "nil")")))
             }
         }
     }
@@ -40,5 +41,4 @@ public class OperationsStreamItem: NSObject {
     public func closeStream() {
         streamingHelper.close()
     }
-    
 }


### PR DESCRIPTION
## Priority
Normal

## Description
Continuing to debug why streaming connections would not halt when closing a stream, I've found more retain cycles caused by closures in the `StreamingHelper` class, and `*StreamItem` classes.

Because the objects aren't released, the stream, once initiated, continues to try to establish a connection (this happens often if the response is 404 - causing high network overhead)

Before the fix, releasing a stream object would leave orphan `StreamingHelper`, `TransactionStreamItem`, `EffectStreamItem`, and `OperationStreamItem` objects.

See the screenshots below for a depiction of the objects in memory graph after the fix.

## Screenshots
This screenshot was taken while the `StellarSDK` stream objects still had references from the host application and the stream was open:
![screen shot 2019-01-31 at 3 26 45 pm](https://user-images.githubusercontent.com/728690/52086258-699f6a80-2574-11e9-8e04-785920cc81aa.png)

This screenshot was taken after the streams had been shut down. Note that the host application objects have been garbage collected, but the `StellarSDK` objects remain (they are not held by `StreamService)`:
![screen shot 2019-01-31 at 4 19 19 pm](https://user-images.githubusercontent.com/728690/52086293-85a30c00-2574-11e9-9a2c-5c77973d1ec3.png)

This screenshot was taken after the fix was applied, and the streams were shut down:
![screen shot 2019-01-31 at 3 27 48 pm](https://user-images.githubusercontent.com/728690/52086375-b7b46e00-2574-11e9-80bc-cca88082de2e.png)

Note that the `StellarSDK` Stream objects are now garbage collected as well.