### PR TITLE
[FEATURE] Adds the 'extras' and other nested properties to BadRequestErrorResponse

### DIFF
--- a/stellarsdk/stellarsdk/responses/error_responses/BadRequestErrorResponse.swift
+++ b/stellarsdk/stellarsdk/responses/error_responses/BadRequestErrorResponse.swift
@@ -10,5 +10,34 @@ import Foundation
 
 ///  Represents a bad request error response from the horizon api (code 400), containing information related to the error
 ///  See [Horizon API](https://www.stellar.org/developers/horizon/reference/errors/bad-request.html "Bad request")
-public class BadRequestErrorResponse: ErrorResponse {}
+public struct ErrorResponseExtras: Decodable {
+    public var envelopeXdr: String
+    public var resultXdr: String
+    public var resultCodes: ErrorResultCodes
 
+    private enum CodingKeys: String, CodingKey {
+        case envelopeXdr = "envelope_xdr"
+        case resultXdr = "result_xdr"
+        case resultCodes = "result_codes"
+    }
+}
+
+public struct ErrorResultCodes: Decodable {
+    public var transaction: String
+    public var operations: [String]
+}
+
+public class BadRequestErrorResponse: ErrorResponse {
+    public var extras: ErrorResponseExtras
+
+    private enum CodingKeys: String, CodingKey {
+        case extras
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        extras = try container.decode(ErrorResponseExtras.self, forKey: .extras)
+
+        try super.init(from: decoder)
+    }
+}


### PR DESCRIPTION
## Priority
Normal

## Description
This adds additional `Decodable` fields to the `BadRequestErrorResponse` object. Since the documentation provides an `extras` key, we can use that to suppliment error handling requests. See the Stellar [REST API documentation page here](https://www.stellar.org/developers/horizon/reference/errors/bad-request.html).

When it is passed through along with a `HorizonErrorResponse`, it's useful to be able to inspect the result codes in the client application so that you can present meaningful error data. For a usage example, see the error handling scenarios of https://github.com/Block-Equity/stellar-ios-wallet/pull/257.

## Screenshots
N/A