### PR TITLE
[FEATURE] Horizon client tracking via request headers

### DIFF
--- a/stellar-ios-mac-sdk.podspec
+++ b/stellar-ios-mac-sdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "stellar-ios-mac-sdk"
-  s.version      = "1.6.0"
+  s.version      = "1.6.1"
   s.summary      = "Fully featured iOS and macOS SDK that provides APIs to build transactions and connect to Horizon server for the Stellar ecosystem."
   s.module_name  = 'stellarsdk'
 

--- a/stellarsdk/stellarsdk.xcodeproj/project.pbxproj
+++ b/stellarsdk/stellarsdk.xcodeproj/project.pbxproj
@@ -2545,6 +2545,7 @@
 			buildConfigurationList = 7445EA10201B106500470E0A /* Build configuration list for PBXNativeTarget "stellarsdk" */;
 			buildPhases = (
 				7445E9F7201B106500470E0A /* Sources */,
+				C5D13C1F224B103C00F0CD2E /* Verify Podspec Version Matches */,
 				7445E9F8201B106500470E0A /* Frameworks */,
 				7445E9F9201B106500470E0A /* Headers */,
 				7445E9FA201B106500470E0A /* Resources */,
@@ -2700,6 +2701,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		C5D13C1F224B103C00F0CD2E /* Verify Podspec Version Matches */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Verify Podspec Version Matches";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "INFO_PLIST=\"${SRCROOT}/stellarsdk/Info\"\nSDK_VERSION=\"$(defaults read $INFO_PLIST CFBundleShortVersionString)\"\nPODSPEC_VERSION=`grep 's.version' ${SRCROOT}/../stellar-ios-mac-sdk.podspec | head -n1 | grep -o '\".*\"' | sed 's/\"//g'`\n\nif [ \"${PODSPEC_VERSION}\" != \"${SDK_VERSION}\" ] ; then\n    echo \"error: Podspec version does not match bundle version. Please update the Info.plist file with the correct version.\"\n    exit 1\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		743DF4E0201F130100713DE7 /* Sources */ = {

--- a/stellarsdk/stellarsdk/Info.plist
+++ b/stellarsdk/stellarsdk/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
## Priority
Normal

## Description
As @ire-and-curses described in #47, the SDK should identify itself via specific fields in the request headers.

This PR implements a simple way to attach those headers to every request sent to Horizon.

Right now, the SDK will send the following data:

`X-Client-Version: <SDK VERSION>`
`X-Client-Name: com.soneso.stellarsdk`

In addition to this, I'm sure it would be useful to identify the specific application that uses the SDK, so I've also attached a field `X-Client-Application: <Host application Bundle ID>` that can be used to identify the specific project using the Soneso SDK. Happy to change that to a different header field if there is one, @ire-and-curses.

Finally, since it's now imperative that the SDK send the correct version along with requests, we need to be using the `.podspec` version inside the `Info.plist` file, but there's no simple mechanism to do so... 

Because Cocoapods and Xcode have no integration, I've written a simple build script run phase that ensures the Podspec version matches the `CFBundleShortVersionString` property in the Info.plist file.

I'd love if either maintainer from Soneso @chelemen-razvan or @christain-rogobete could chime in on the strategy for versioning! Maybe there's a better way...

## Output
```
(lldb) po urlRequest
▿ https://horizon-testnet.stellar.org/accounts/AAAAA
  ▿ url : Optional<URL>
    ▿ some : https://horizon-testnet.stellar.org/accounts/AAAAA
      - _url : https://horizon-testnet.stellar.org/accounts/AAAAA
  - cachePolicy : 0
  - timeoutInterval : 60.0
  - mainDocumentURL : nil
  - networkServiceType : __C.NSURLRequestNetworkServiceType
  - allowsCellularAccess : true
  ▿ httpMethod : Optional<String>
    - some : "GET"
  ▿ allHTTPHeaderFields : Optional<Dictionary<String, String>>
    ▿ some : 3 elements
      ▿ 0 : 2 elements
        - key : "X-Client-Application"
        - value : "com.soneso.stellarsdkTests-Host"
      ▿ 1 : 2 elements
        - key : "X-Client-Name"
        - value : "com.soneso.stellarsdk"
      ▿ 2 : 2 elements
        - key : "X-Client-Version"
        - value : "1.6.1"
  - httpBody : nil
  - httpBodyStream : nil
  - httpShouldHandleCookies : true
  - httpShouldUsePipelining : false
```