### PR TITLE
[FEATURE] Adds support to compile the SDK with Swift 5

### DIFF
--- a/stellarsdk/stellarsdk.xcodeproj/project.pbxproj
+++ b/stellarsdk/stellarsdk.xcodeproj/project.pbxproj
@@ -3624,7 +3624,6 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/stellarsdk/osx $(SRCROOT)/stellarsdk/libs/ed25519-C/**";
-				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -3649,7 +3648,6 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/stellarsdk/libs/ed25519-C/** $(SRCROOT)/stellarsdk/osx";
-				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -3667,7 +3665,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soneso.stellarsdk-macOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -3685,7 +3682,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soneso.stellarsdk-macOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -3699,7 +3695,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soneso.stellarsdkTests-Host";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -3714,7 +3709,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soneso.stellarsdkTests-Host";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -3730,7 +3724,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soneso.stellarsdkTests-HostTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/stellarsdkTests-Host.app/stellarsdkTests-Host";
 			};
@@ -3747,7 +3740,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soneso.stellarsdkTests-HostTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/stellarsdkTests-Host.app/stellarsdkTests-Host";
 			};
@@ -3763,7 +3755,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soneso.stellarsdkTests-HostUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = "stellarsdkTests-Host";
 			};
@@ -3779,7 +3770,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soneso.stellarsdkTests-HostUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = "stellarsdkTests-Host";
 			};
@@ -3840,6 +3830,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -3892,6 +3883,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -3920,7 +3912,6 @@
 				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(SRCROOT)/stellarsdk/libs/ed25519-C/**";
 				"SWIFT_INCLUDE_PATHS[sdk=iphonesimulator*]" = "$(SRCROOT)/stellarsdk/libs/ed25519-C/**";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -3946,7 +3937,6 @@
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/stellarsdk/libs/ed25519-C/**";
 				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(SRCROOT)/stellarsdk/libs/ed25519-C/**";
 				"SWIFT_INCLUDE_PATHS[sdk=iphonesimulator*]" = "$(SRCROOT)/stellarsdk/libs/ed25519-C/**";
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -3962,7 +3952,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.soneso.stellarsdkTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/stellarsdkTests-Host.app/stellarsdkTests-Host";
 			};
@@ -3979,7 +3968,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.soneso.stellarsdkTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/stellarsdkTests-Host.app/stellarsdkTests-Host";
 			};
@@ -4040,6 +4028,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG XC9";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -4067,7 +4056,6 @@
 				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(SRCROOT)/stellarsdk/libs/ed25519-C/** $(SRCROOT)/stellarsdk/iphone";
 				"SWIFT_INCLUDE_PATHS[sdk=iphonesimulator*]" = "$(SRCROOT)/stellarsdk/libs/ed25519-C/** $(SRCROOT)/stellarsdk/simulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Debug - Xcode 9";
@@ -4083,7 +4071,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.soneso.stellarsdkTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/stellarsdkTests-Host.app/stellarsdkTests-Host";
 			};
@@ -4110,7 +4097,6 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/stellarsdk/osx $(SRCROOT)/stellarsdk/libs/ed25519-C/**";
-				SWIFT_VERSION = 4.2;
 			};
 			name = "Debug - Xcode 9";
 		};
@@ -4128,7 +4114,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soneso.stellarsdk-macOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.0;
 			};
 			name = "Debug - Xcode 9";
 		};
@@ -4142,7 +4127,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soneso.stellarsdkTests-Host";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Debug - Xcode 9";
@@ -4158,7 +4142,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soneso.stellarsdkTests-HostTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/stellarsdkTests-Host.app/stellarsdkTests-Host";
 			};
@@ -4174,7 +4157,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soneso.stellarsdkTests-HostUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = "stellarsdkTests-Host";
 			};
@@ -4228,6 +4210,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = XC9;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -4255,7 +4238,6 @@
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/stellarsdk/libs/ed25519-C/**";
 				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(SRCROOT)/stellarsdk/libs/ed25519-C/** $(SRCROOT)/stellarsdk/iphone";
 				"SWIFT_INCLUDE_PATHS[sdk=iphonesimulator*]" = "$(SRCROOT)/stellarsdk/libs/ed25519-C/** $(SRCROOT)/stellarsdk/simulator";
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Release - Xcode 9";
@@ -4271,7 +4253,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.soneso.stellarsdkTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/stellarsdkTests-Host.app/stellarsdkTests-Host";
 			};
@@ -4298,7 +4279,6 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/stellarsdk/libs/ed25519-C/** $(SRCROOT)/stellarsdk/osx";
-				SWIFT_VERSION = 4.2;
 			};
 			name = "Release - Xcode 9";
 		};
@@ -4316,7 +4296,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soneso.stellarsdk-macOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.0;
 			};
 			name = "Release - Xcode 9";
 		};
@@ -4330,7 +4309,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soneso.stellarsdkTests-Host";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Release - Xcode 9";
@@ -4346,7 +4324,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soneso.stellarsdkTests-HostTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/stellarsdkTests-Host.app/stellarsdkTests-Host";
 			};
@@ -4362,7 +4339,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.soneso.stellarsdkTests-HostUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = "stellarsdkTests-Host";
 			};

--- a/stellarsdk/stellarsdk/uri_scheme/URIScheme.swift
+++ b/stellarsdk/stellarsdk/uri_scheme/URIScheme.swift
@@ -210,7 +210,7 @@ public class URIScheme: NSObject {
     
     /// Sends the transaction to the network.
     private func submitTransaction(transactionXDR: TransactionXDR?, callback: String? = nil, keyPair: KeyPair, completion: @escaping SubmitTransactionClosure) {
-        if let transactionEncodedEnvelope = try? transactionXDR?.encodedEnvelope(), let transactionEnvelope = transactionEncodedEnvelope {
+        if let transactionEncodedEnvelope = try? transactionXDR?.encodedEnvelope() {
             if var callback = callback, callback.hasPrefix("uri:") {
                 callback = String(callback.dropLast(4))
                 let serviceHelper = ServiceHelper(baseURL: callback)
@@ -225,7 +225,7 @@ public class URIScheme: NSObject {
                     }
                 }
             } else {
-                self.sdk.transactions.postTransaction(transactionEnvelope: transactionEnvelope, response: { (response) -> (Void) in
+                self.sdk.transactions.postTransaction(transactionEnvelope: transactionEncodedEnvelope, response: { (response) -> (Void) in
                     switch response {
                     case .success(_):
                         completion(.success)

--- a/stellarsdk/stellarsdk/uri_scheme/validator/URISchemeValidator.swift
+++ b/stellarsdk/stellarsdk/uri_scheme/validator/URISchemeValidator.swift
@@ -16,7 +16,7 @@ public enum SignURLEnum {
 
 /// An enum used to diferentiate between successful and failed URIScheme validity.
 public enum URISchemeIsValidEnum {
-    case success()
+    case success
     case failure(URISchemeErrors)
 }
 
@@ -62,7 +62,7 @@ public class URISchemeValidator: NSObject {
                             if let signerPublicKey = try? PublicKey(accountId: uriRequestSigningKey) {
                                 if let signature = self.getSignatureField(forURL: url) {
                                     if self.verify(forURL: url, urlEncodedBase64Signature: signature, signerPublicKey: signerPublicKey) {
-                                        completion(.success())
+                                        completion(.success)
                                     } else {
                                         completion(.failure(.invalidSignature))
                                     }

--- a/stellarsdk/stellarsdk/web_authentication/WebAuthenticator.swift
+++ b/stellarsdk/stellarsdk/web_authentication/WebAuthenticator.swift
@@ -172,9 +172,9 @@ public class WebAuthenticator {
             switch result {
             case .success(let data):
                 if let response = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-                    if let challenge = response?["transaction"] as? String {
+                    if let challenge = response["transaction"] as? String {
                         completion(.success(challenge: challenge))
-                    } else if let error = response?["error"] as? String {
+                    } else if let error = response["error"] as? String {
                         completion(.failure(error: .requestFailed(message: error)))
                     } else {
                         completion(.failure(error: .parsingResponseFailed(message: "Invalid JSON")))
@@ -274,9 +274,9 @@ public class WebAuthenticator {
             switch result {
             case .success(let data):
                 if let response = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-                    if let token = response?["token"] as? String {
+                    if let token = response["token"] as? String {
                         completion(.success(jwtToken: token))
-                    } else if let error = response?["error"] as? String {
+                    } else if let error = response["error"] as? String {
                         completion(.failure(error: .requestFailed(message: error)))
                     } else {
                         completion(.failure(error: .parsingResponseFailed(message: "Invalid JSON")))

--- a/stellarsdk/stellarsdkTests-Host/AppDelegate.swift
+++ b/stellarsdk/stellarsdkTests-Host/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/stellarsdk/stellarsdkTests/uri_scheme/URISchemeTestCase.swift
+++ b/stellarsdk/stellarsdkTests/uri_scheme/URISchemeTestCase.swift
@@ -140,7 +140,7 @@ class URISchemeTestCase: XCTestCase {
         tomlResponseMock = TomlResponseMock(address: "place.domain.com")
         uriValidator.checkURISchemeIsValid(url: validURL) { (response) -> (Void) in
             switch response {
-                case .success():
+                case .success:
                     XCTAssert(true)
                 case .failure(let error):
                     print("ValidURIScheme Error: \(error)")
@@ -280,7 +280,7 @@ class URISchemeTestCase: XCTestCase {
             expectation.fulfill()
         }) { (response) -> (Void) in
             switch response {
-            case .success():
+            case .success:
                 XCTAssert(true)
             case .failure(_):
                 XCTAssert(false)
@@ -296,7 +296,7 @@ class URISchemeTestCase: XCTestCase {
         
         uriValidator.checkURISchemeIsValid(url: validURL) { (response) -> (Void) in
             switch response {
-            case .success():
+            case .success:
                 XCTAssert(false)
             case .failure(let error):
                 print("ValidURIScheme Error: \(error)")


### PR DESCRIPTION
## Priority
High

## Description
Now that Swift 5 is out, applications are going to want to compile the SDK using the new ABI-stable release.

This PR completes the minimum viable amount of changes for the SDK to compile.

## Notes
There are tons of warnings as a result of the version bump that I didn't want to address quite yet without some discussion. Since a lot of these stem from 3rd party dependencies (like Cryptoswift, HDWallet, etc.) that have already been updated for Swift 5, there's a good argument to be made for us to have a look at re-importing those libraries, or even have a better strategy for including those dependencies in the project.