### PR TITLE
Changes scope of CryptoSwift extensions to internal

### DIFF
--- a/stellarsdk/stellarsdk/libs/CryptoSwift/Array+Extension.swift
+++ b/stellarsdk/stellarsdk/libs/CryptoSwift/Array+Extension.swift
@@ -44,7 +44,7 @@ extension Array {
 
 extension Array where Element == UInt8 {
 
-    public init(hex: String) {
+    internal init(hex: String) {
         self.init(reserveCapacity: hex.unicodeScalars.lazy.underestimatedCount)
         var buffer: UInt8?
         var skip = hex.hasPrefix("0x") ? 2 : 0

--- a/stellarsdk/stellarsdk/libs/CryptoSwift/Array+Extensions.swift
+++ b/stellarsdk/stellarsdk/libs/CryptoSwift/Array+Extensions.swift
@@ -13,9 +13,9 @@
 //  - This notice may not be removed or altered from any source or binary distribution.
 //
 
-public extension Array where Element == UInt8 {
+internal extension Array where Element == UInt8 {
 
-    public func toHexString() -> String {
+    func toHexString() -> String {
         return `lazy`.reduce("") {
             var s = String($1, radix: 16)
             if s.count == 1 {
@@ -26,57 +26,57 @@ public extension Array where Element == UInt8 {
     }
 }
 
-public extension Array where Element == UInt8 {
+internal extension Array where Element == UInt8 {
 
-    public func md5() -> [Element] {
+    func md5() -> [Element] {
         return Digest.md5(self)
     }
 
-    public func sha1() -> [Element] {
+    func sha1() -> [Element] {
         return Digest.sha1(self)
     }
 
-    public func sha224() -> [Element] {
+    func sha224() -> [Element] {
         return Digest.sha224(self)
     }
 
-    public func sha256() -> [Element] {
+    func sha256() -> [Element] {
         return Digest.sha256(self)
     }
 
-    public func sha384() -> [Element] {
+    func sha384() -> [Element] {
         return Digest.sha384(self)
     }
 
-    public func sha512() -> [Element] {
+    func sha512() -> [Element] {
         return Digest.sha512(self)
     }
 
-    public func sha2(_ variant: SHA2.Variant) -> [Element] {
+    func sha2(_ variant: SHA2.Variant) -> [Element] {
         return Digest.sha2(self, variant: variant)
     }
 
-    public func sha3(_ variant: SHA3.Variant) -> [Element] {
+    func sha3(_ variant: SHA3.Variant) -> [Element] {
         return Digest.sha3(self, variant: variant)
     }
 
-    public func crc32(seed: UInt32? = nil, reflect: Bool = true) -> UInt32 {
+    func crc32(seed: UInt32? = nil, reflect: Bool = true) -> UInt32 {
         return Checksum.crc32(self, seed: seed, reflect: reflect)
     }
 
-    public func crc16(seed: UInt16? = nil) -> UInt16 {
+    func crc16(seed: UInt16? = nil) -> UInt16 {
         return Checksum.crc16(self, seed: seed)
     }
 
-    public func encrypt(cipher: Cipher) throws -> [Element] {
+    func encrypt(cipher: Cipher) throws -> [Element] {
         return try cipher.encrypt(slice)
     }
 
-    public func decrypt(cipher: Cipher) throws -> [Element] {
+    func decrypt(cipher: Cipher) throws -> [Element] {
         return try cipher.decrypt(slice)
     }
 
-    public func authenticate<A: Authenticator>(with authenticator: A) throws -> [Element] {
+    func authenticate<A: Authenticator>(with authenticator: A) throws -> [Element] {
         return try authenticator.authenticate(self)
     }
 }

--- a/stellarsdk/stellarsdk/libs/CryptoSwift/Foundation/Array+Foundation.swift
+++ b/stellarsdk/stellarsdk/libs/CryptoSwift/Foundation/Array+Foundation.swift
@@ -15,13 +15,13 @@
 
 import Foundation
 
-public extension Array where Element == UInt8 {
+internal extension Array where Element == UInt8 {
 
-    public func toBase64() -> String? {
+    func toBase64() -> String? {
         return Data(bytes: self).base64EncodedString()
     }
 
-    public init(base64: String) {
+    init(base64: String) {
         self.init()
 
         guard let decodedData = Data(base64Encoded: base64) else {

--- a/stellarsdk/stellarsdk/libs/CryptoSwift/Foundation/Data+Extension.swift
+++ b/stellarsdk/stellarsdk/libs/CryptoSwift/Foundation/Data+Extension.swift
@@ -18,7 +18,7 @@ import Foundation
 extension Data {
 
     /// Two octet checksum as defined in RFC-4880. Sum of all octets, mod 65536
-    public func checksum() -> UInt16 {
+    internal func checksum() -> UInt16 {
         var s: UInt32 = 0
         var bytesArray = bytes
         for i in 0..<bytesArray.count {
@@ -28,66 +28,66 @@ extension Data {
         return UInt16(s)
     }
 
-    public func md5() -> Data {
+    internal func md5() -> Data {
         return Data(bytes: Digest.md5(bytes))
     }
 
-    public func sha1() -> Data {
+    internal func sha1() -> Data {
         return Data(bytes: Digest.sha1(bytes))
     }
 
-    public func sha224() -> Data {
+    internal func sha224() -> Data {
         return Data(bytes: Digest.sha224(bytes))
     }
 
-    public func sha256() -> Data {
+    internal func sha256() -> Data {
         return Data(bytes: Digest.sha256(bytes))
     }
 
-    public func sha384() -> Data {
+    internal func sha384() -> Data {
         return Data(bytes: Digest.sha384(bytes))
     }
 
-    public func sha512() -> Data {
+    internal func sha512() -> Data {
         return Data(bytes: Digest.sha512(bytes))
     }
 
-    public func sha3(_ variant: SHA3.Variant) -> Data {
+    internal func sha3(_ variant: SHA3.Variant) -> Data {
         return Data(bytes: Digest.sha3(bytes, variant: variant))
     }
 
-    public func crc32(seed: UInt32? = nil, reflect: Bool = true) -> Data {
+    internal func crc32(seed: UInt32? = nil, reflect: Bool = true) -> Data {
         return Data(bytes: Checksum.crc32(bytes, seed: seed, reflect: reflect).bytes())
     }
 
-    public func crc16(seed: UInt16? = nil) -> Data {
+    internal func crc16(seed: UInt16? = nil) -> Data {
         return Data(bytes: Checksum.crc16(bytes, seed: seed).bytes())
     }
 
-    public func encrypt(cipher: Cipher) throws -> Data {
+    internal func encrypt(cipher: Cipher) throws -> Data {
         return Data(bytes: try cipher.encrypt(bytes.slice))
     }
 
-    public func decrypt(cipher: Cipher) throws -> Data {
+    internal func decrypt(cipher: Cipher) throws -> Data {
         return Data(bytes: try cipher.decrypt(bytes.slice))
     }
 
-    public func authenticate(with authenticator: Authenticator) throws -> Data {
+    internal func authenticate(with authenticator: Authenticator) throws -> Data {
         return Data(bytes: try authenticator.authenticate(bytes))
     }
 }
 
 extension Data {
 
-    public init(hex: String) {
+    internal init(hex: String) {
         self.init(bytes: Array<UInt8>(hex: hex))
     }
 
-    public var bytes: Array<UInt8> {
+    internal var bytes: Array<UInt8> {
         return Array(self)
     }
 
-    public func toHexString() -> String {
+    internal func toHexString() -> String {
         return bytes.toHexString()
     }
 }

--- a/stellarsdk/stellarsdk/libs/CryptoSwift/Foundation/String+FoundationExtension.swift
+++ b/stellarsdk/stellarsdk/libs/CryptoSwift/Foundation/String+FoundationExtension.swift
@@ -18,7 +18,7 @@ import Foundation
 extension String {
 
     /// Return Base64 back to String
-    public func decryptBase64ToString(cipher: Cipher) throws -> String {
+    func decryptBase64ToString(cipher: Cipher) throws -> String {
         guard let decodedData = Data(base64Encoded: self, options: []) else {
             throw CipherError.decrypt
         }
@@ -32,7 +32,7 @@ extension String {
         throw CipherError.decrypt
     }
 
-    public func decryptBase64(cipher: Cipher) throws -> Array<UInt8> {
+    func decryptBase64(cipher: Cipher) throws -> Array<UInt8> {
         guard let decodedData = Data(base64Encoded: self, options: []) else {
             throw CipherError.decrypt
         }

--- a/stellarsdk/stellarsdk/libs/CryptoSwift/String+Extension.swift
+++ b/stellarsdk/stellarsdk/libs/CryptoSwift/String+Extension.swift
@@ -16,55 +16,55 @@
 /** String extension */
 extension String {
 
-    public var bytes: Array<UInt8> {
+    internal var bytes: Array<UInt8> {
         return data(using: String.Encoding.utf8, allowLossyConversion: true)?.bytes ?? Array(utf8)
     }
 
-    public func md5() -> String {
+    internal func md5() -> String {
         return bytes.md5().toHexString()
     }
 
-    public func sha1() -> String {
+    internal func sha1() -> String {
         return bytes.sha1().toHexString()
     }
 
-    public func sha224() -> String {
+    internal func sha224() -> String {
         return bytes.sha224().toHexString()
     }
 
-    public func sha256() -> String {
+    internal func sha256() -> String {
         return bytes.sha256().toHexString()
     }
 
-    public func sha384() -> String {
+    internal func sha384() -> String {
         return bytes.sha384().toHexString()
     }
 
-    public func sha512() -> String {
+    internal func sha512() -> String {
         return bytes.sha512().toHexString()
     }
 
-    public func sha3(_ variant: SHA3.Variant) -> String {
+    internal func sha3(_ variant: SHA3.Variant) -> String {
         return bytes.sha3(variant).toHexString()
     }
 
-    public func crc32(seed: UInt32? = nil, reflect: Bool = true) -> String {
+    internal func crc32(seed: UInt32? = nil, reflect: Bool = true) -> String {
         return bytes.crc32(seed: seed, reflect: reflect).bytes().toHexString()
     }
 
-    public func crc16(seed: UInt16? = nil) -> String {
+    internal func crc16(seed: UInt16? = nil) -> String {
         return bytes.crc16(seed: seed).bytes().toHexString()
     }
 
     /// - parameter cipher: Instance of `Cipher`
     /// - returns: hex string of bytes
-    public func encrypt(cipher: Cipher) throws -> String {
+    internal func encrypt(cipher: Cipher) throws -> String {
         return try bytes.encrypt(cipher: cipher).toHexString()
     }
 
     /// - parameter cipher: Instance of `Cipher`
     /// - returns: base64 encoded string of encrypted bytes
-    public func encryptToBase64(cipher: Cipher) throws -> String? {
+    internal func encryptToBase64(cipher: Cipher) throws -> String? {
         return try bytes.encrypt(cipher: cipher).toBase64()
     }
 
@@ -72,7 +72,7 @@ extension String {
 
     /// - parameter authenticator: Instance of `Authenticator`
     /// - returns: hex string of string
-    public func authenticate<A: Authenticator>(with authenticator: A) throws -> String {
+    internal func authenticate<A: Authenticator>(with authenticator: A) throws -> String {
         return try bytes.authenticate(with: authenticator).toHexString()
     }
 }


### PR DESCRIPTION
Changes the scope of some of the extensions created for primitive types from CryptoSwift to be internal versus public. This is to avoid namespace conflicts related functionality for consumers who use both CryptoSwift + stellar sdk.

Consumers of the stellar sdk also shouldn't be using the sdk to extend functionality to their own primitive types. If they wish to convert Data objects to bytes, that is functionality they should be able to do within their own applications as this does not relate to stellar related operations.