### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -2,16 +2,16 @@
 import PackageDescription
 
 let package = Package(
-    name: "StellarSDK",
+    name: "stellarsdk",
     products: [
         .library(
-            name: "StellarSDK", 
-            targets: ["StellarSDK"]
+            name: "stellarsdk", 
+            targets: ["stellarsdk"]
         )
     ],
     targets: [
         .target(
-            name: "StellarSDK",
+            name: "stellarsdk",
             dependencies: [
                 .target(name: "ed25519C")
             ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "StellarSDK",
+    products: [
+        .library(
+            name: "StellarSDK", 
+            targets: ["StellarSDK"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "StellarSDK",
+            dependencies: [
+                .target(name: "ed25519C")
+            ],
+            path: "stellarsdk/stellarsdk",
+            exclude: [
+                "Info.plist",
+                "stellarsdk.h",
+                "libs/ed25519-C"
+            ]
+        ),
+        .target(
+            name: "ed25519C",
+            path: "stellarsdk/stellarsdk/libs/ed25519-C",
+            publicHeadersPath: "include"
+        )
+    ]
+)


### PR DESCRIPTION
Projects consuming this SDK may benefit from having a Package.swift file to use it from Swift Package Manager. 

The project dependencies are currently included under `libs/` - A good move forward would be to rely on the upstream packages instead. This work can be done outside of this Pull Request