### PR TITLE
[FIX] Fixed  {numerator, denominator} pair should be represented as 32 bit signed integers.

### DIFF
--- a/stellarsdk/stellarsdk/responses/offer_responses/OfferPriceResponse.swift
+++ b/stellarsdk/stellarsdk/responses/offer_responses/OfferPriceResponse.swift
@@ -14,10 +14,10 @@ import Foundation
 public class OfferPriceResponse: NSObject, Decodable {
     
     /// represent the buy price of the currencies on offer.
-    public var numerator:Int
+    public var numerator:Int32
     
     /// represent the sell price of the currencies on offer.
-    public var denominator:Int
+    public var denominator:Int32
     
     // Properties to encode and decode
     enum CodingKeys: String, CodingKey {
@@ -33,7 +33,7 @@ public class OfferPriceResponse: NSObject, Decodable {
     public required init(from decoder: Decoder) throws {
         
         let values = try decoder.container(keyedBy: CodingKeys.self)
-        numerator = try values.decode(Int.self, forKey: .numerator)
-        denominator = try values.decode(Int.self, forKey: .denominator)
+        numerator = try values.decode(Int32.self, forKey: .numerator)
+        denominator = try values.decode(Int32.self, forKey: .denominator)
     }
 }


### PR DESCRIPTION
Please, review.

Prices are specified as a {numerator, denominator} pair with both components of the fraction represented as 32 bit signed integers

https://developers.stellar.org/docs/glossary/decentralized-exchange/#price