### PR TITLE
Added `error` case to AnchorTransactionStatus.

### DIFF
--- a/stellarsdk/stellarsdk/transfer_server_protocol/responses/AnchorTransactionsResponse.swift
+++ b/stellarsdk/stellarsdk/transfer_server_protocol/responses/AnchorTransactionsResponse.swift
@@ -40,6 +40,8 @@ public enum AnchorTransactionStatus: String {
     case tooSmall = "too_small"
     /// deposit/withdrawal size exceeded max_amount
     case tooLarge = "too_large"
+    /// catch-all for any error not enumerated above
+    case error = "error"
 }
 
 public struct AnchorTransactionsResponse: Decodable {


### PR DESCRIPTION
Please, review.

Added `error` case for AnchorTransactionStatus.

status should be one of:

```
incomplete -- there is not yet enough information for this transaction to be initiated. Perhaps the user has not yet entered necessary info in an interactive flow.
pending_user_transfer_start -- the user has not yet initiated their transfer to the anchor. This is the next necessary step in any deposit or withdrawal flow after transitioning from incomplete.
pending_external -- deposit/withdrawal has been submitted to external network, but is not yet confirmed. This is the status when waiting on Bitcoin or other external crypto network to complete a transaction, or when waiting on a bank transfer.
pending_anchor -- deposit/withdrawal is being processed internally by anchor. This can also be used when the anchor must verify KYC information prior to deposit/withdrawal.
pending_stellar -- deposit/withdrawal operation has been submitted to Stellar network, but is not yet confirmed.
pending_trust -- the user must add a trustline for the asset for the deposit to complete.
pending_user -- the user must take additional action before the deposit / withdrawal can complete, for example an email or 2fa confirmation of a withdraw.
completed -- deposit/withdrawal fully completed.
no_market -- could not complete deposit because no satisfactory asset/XLM market was available to create the account.
too_small -- deposit/withdrawal size less than min_amount.
too_large -- deposit/withdrawal size exceeded max_amount.
error -- catch-all for any error not enumerated above.
```

Please, check reference:
 https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#fields-for-withdraw-transactions

https://github.com/stellar/django-polaris/blob/27b4e911f0fce32fa9e90fdd365af3de7017324a/polaris/polaris/models.py#L347