### PR TITLE
Add storing lastEventId in dictionary.

### DIFF
--- a/stellarsdk/stellarsdk/utils/EventSource.swift
+++ b/stellarsdk/stellarsdk/utils/EventSource.swift
@@ -36,7 +36,7 @@ open class EventSource: NSObject, URLSessionDataDelegate {
     fileprivate let validNewlineCharacters = ["\r\n", "\n", "\r"]
     
     var event = Dictionary<String, String>()
-    
+    var defaults = Dictionary<String, String>()
     
     public init(url: String, headers: [String : String] = [:]) {
         
@@ -280,16 +280,13 @@ open class EventSource: NSObject, URLSessionDataDelegate {
     internal var lastEventID: String? {
         set {
             if let lastEventID = newValue {
-                let defaults = UserDefaults.standard
-                defaults.set(lastEventID, forKey: lastEventIDKey)
-                defaults.synchronize()
+                defaults[lastEventIDKey] = lastEventID
             }
         }
         
         get {
-            let defaults = UserDefaults.standard
             
-            if let lastEventID = defaults.string(forKey: lastEventIDKey) {
+            if let lastEventID = defaults[lastEventIDKey] {
                 return lastEventID
             }
             return nil


### PR DESCRIPTION
Please, consider storing `Last-Event-Id` in the local dictionary instead of UserDefaults in the `EventSource` implementation. 

In our use case, we want to stream only real-time events starting from `now` when the stream launched, but the current Horizon implementation will override the `now` cursor if `Last-Event-Id` is present.
https://github.com/stellar/go/blob/71cab9c80d24d0f6287b30860129e3f8bff70b33/services/horizon/internal/httpx/handler.go#L238

UserDefaults persists `Last-Event-Id` on the user device between app launches and that causes overriding of `now` cursor with an id of older events.

As we see, Java SDK also does not use any persistence storage for `Last-Event-Id` property and just handles it locally.
https://github.com/stellar/java-stellar-sdk/blob/ce7de4f074bc16416b537e583bf06227315b879c/src/main/java/org/stellar/sdk/requests/SSEStream.java#L35

Thanks.