### PR TITLE
[FIX] Protect access to lastEventId with the main queue.

### DIFF
--- a/stellarsdk/stellarsdk/utils/EventSource.swift
+++ b/stellarsdk/stellarsdk/utils/EventSource.swift
@@ -259,8 +259,10 @@ open class EventSource: NSObject, URLSessionDataDelegate {
         }
         
         for parsedEvent in parsedEvents {
-            self.lastEventID = parsedEvent.id
-            
+            DispatchQueue.main.async { [weak self] in
+                self?.lastEventID = parsedEvent.id
+            }
+              
             if parsedEvent.event == nil {
                 if let data = parsedEvent.data, let onMessage = self.onMessageCallback {
                     DispatchQueue.main.async { [weak self] in


### PR DESCRIPTION
The Swift language dictionary data structure is not thread-safe by default.
To prevent multi-threading issues with access to the `lastEventId` property it is wrapped with `DispatchQueue.main.async`. 
