### PR TITLE
Update EventSource with closing stream before re-connect.

### DIFF
--- a/stellarsdk/stellarsdk/utils/EventSource.swift
+++ b/stellarsdk/stellarsdk/utils/EventSource.swift
@@ -179,6 +179,7 @@ open class EventSource: NSObject, URLSessionDataDelegate {
             let nanoseconds = Double(self.retryTime) / 1000.0 * Double(NSEC_PER_SEC)
             let delayTime = DispatchTime.now() + Double(Int64(nanoseconds)) / Double(NSEC_PER_SEC)
             DispatchQueue.main.asyncAfter(deadline: delayTime) { [weak self] in
+                self?.close()
                 self?.connect()
             }
             return


### PR DESCRIPTION
@christian-rogobete Please, review:

Added close() method call before re-connecting to invalidate previous URLSession and prevent memory leak. URLSession creates strong reference to its delegate in our case `EventSource` object and if not invalidated properly it will remain in memory.

Reference:
https://developer.apple.com/documentation/foundation/urlsession

> The session object keeps a strong reference to the delegate until your app exits or explicitly invalidates the session. If you don’t invalidate the session, your app leaks memory until the app terminates.

