### PR TITLE
Made lastModifiedTime optional

### DIFF
--- a/stellarsdk/stellarsdk/responses/account_responses/AccountResponse.swift
+++ b/stellarsdk/stellarsdk/responses/account_responses/AccountResponse.swift
@@ -59,7 +59,7 @@ public class AccountResponse: NSObject, Decodable, TransactionAccount {
     
     public var lastModifiedLedger:Int
     
-    public var lastModifiedTime:String
+    public var lastModifiedTime:String?
     
     // Properties to encode and decode
     enum CodingKeys: String, CodingKey {
@@ -119,7 +119,7 @@ public class AccountResponse: NSObject, Decodable, TransactionAccount {
         sequenceLedger = try values.decodeIfPresent(Int.self, forKey: .sequenceLedger)
         sequenceTime = try values.decodeIfPresent(String.self, forKey: .sequenceTime)
         lastModifiedLedger = try values.decode(Int.self, forKey: .lastModifiedLedger)
-        lastModifiedTime = try values.decode(String.self, forKey: .lastModifiedTime)
+        lastModifiedTime = try values.decodeIfPresent(String.self, forKey: .lastModifiedTime)
             
     }
     

--- a/stellarsdk/stellarsdk/responses/liquidity_pool_responses/LiquidityPoolResponse.swift
+++ b/stellarsdk/stellarsdk/responses/liquidity_pool_responses/LiquidityPoolResponse.swift
@@ -19,7 +19,7 @@ public class LiquidityPoolResponse: NSObject, Decodable {
     public var reserves:[ReserveResponse]
     public var pagingToken:String
     public var lastModifiedLedger:Int
-    public var lastModifiedTime:String
+    public var lastModifiedTime:String?
     
     // Properties to encode and decode
     private enum CodingKeys: String, CodingKey {
@@ -52,6 +52,6 @@ public class LiquidityPoolResponse: NSObject, Decodable {
         reserves = try values.decode([ReserveResponse].self, forKey: .reserves)
         pagingToken = try values.decode(String.self, forKey: .pagingToken)
         lastModifiedLedger = try values.decode(Int.self, forKey: .lastModifiedLedger)
-        lastModifiedTime = try values.decode(String.self, forKey: .lastModifiedTime)
+        lastModifiedTime = try values.decodeIfPresent(String.self, forKey: .lastModifiedTime)
     }
 }

--- a/stellarsdk/stellarsdk/responses/offer_responses/OfferResponse.swift
+++ b/stellarsdk/stellarsdk/responses/offer_responses/OfferResponse.swift
@@ -42,7 +42,7 @@ public class OfferResponse: NSObject, Decodable {
     public var sponsor:String?
   
     public var lastModifiedLedger:Int
-    public var lastModifiedTime:String
+    public var lastModifiedTime:String?
     
     private enum CodingKeys: String, CodingKey {
         
@@ -79,6 +79,6 @@ public class OfferResponse: NSObject, Decodable {
         price = try values.decode(String.self, forKey: .price)
         sponsor = try values.decodeIfPresent(String.self, forKey: .sponsor)
         lastModifiedLedger = try values.decode(Int.self, forKey: .lastModifiedLedger)
-        lastModifiedTime = try values.decode(String.self, forKey: .lastModifiedTime)
+        lastModifiedTime = try values.decodeIfPresent(String.self, forKey: .lastModifiedTime)
     }
 }


### PR DESCRIPTION
The `lastModifiedTime` field in the JSON from some horizon nodes can in some cases be `nil`. This field has now been made optional to prevent any parsing errors when this occurs.