### PR TITLE
Added pending_user_transfer_complete status to AnchorTransactionStatus.

### DIFF
--- a/stellarsdk/stellarsdk/transfer_server_protocol/responses/AnchorTransactionsResponse.swift
+++ b/stellarsdk/stellarsdk/transfer_server_protocol/responses/AnchorTransactionsResponse.swift
@@ -28,6 +28,9 @@ public enum AnchorTransactionStatus: String {
     case pendingUser = "pending_user"
     /// the user has not yet initiated their transfer to the anchor. This is the necessary first step in any deposit or withdrawal flow.
     case pendingUserTransferStart = "pending_user_transfer_start"
+    // if anchor detects the payment is fulfilled and the funds is ready for the user to pick up.
+    // This is the most common status after pending_user_transfer_start if the user must pick up the funds in person.
+    case pendingUserTransferComplete = "pending_user_transfer_complete"
     /// certain pieces of information need to be updated by the user.
     case pendingCustomerInfoUpdate = "pending_customer_info_update"
     /// certain pieces of information need to be updated by the user.


### PR DESCRIPTION
Added `pending_user_transfer_complete` to the AnchorTransactionStatus enumeration. This additional status aligns with the current guidance for anchors in the interactive popup handling and ensures that implementation is compliant with SEP-0024.

SEP-0024:
https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#guidance-for-anchors-closing-the-interactive-popup

Reference from JS SDK:
https://github.com/stellar/js-stellar-wallets/blob/master/src/constants/transfers.ts

