### PR TITLE
Updated ClaimableBalanceResponse lastModifiedTime parsing.

### DIFF
--- a/stellarsdk/stellarsdk/responses/claimable_balances_responses/ClaimableBalanceResponse.swift
+++ b/stellarsdk/stellarsdk/responses/claimable_balances_responses/ClaimableBalanceResponse.swift
@@ -18,7 +18,7 @@ public class ClaimableBalanceResponse: NSObject, Decodable {
     public var amount:String
     public var sponsor:String
     public var lastModifiedLedger:Int
-    public var lastModifiedTime:String
+    public var lastModifiedTime:String?
     public var pagingToken:String
     public var claimants:[ClaimantResponse]
    
@@ -56,7 +56,7 @@ public class ClaimableBalanceResponse: NSObject, Decodable {
         amount = try values.decode(String.self, forKey: .amount)
         sponsor = try values.decode(String.self, forKey: .sponsor)
         lastModifiedLedger = try values.decode(Int.self, forKey: .lastModifiedLedger)
-        lastModifiedTime = try values.decode(String.self, forKey: .lastModifiedTime)
+        lastModifiedTime = try values.decodeIfPresent(String.self, forKey: .lastModifiedTime)
         pagingToken = try values.decode(String.self, forKey: .pagingToken)
     }
 }


### PR DESCRIPTION
Due to recent changes in the Stellar Development Foundation’s Horizon API, historical data will now be limited to one year. (https://stellar.org/blog/foundation-news/sdf-s-horizon-limiting-data-to-1-year) 

As a result, some claimable balance responses may return a `null` value for the `lastModifiedTime` field.

To prevent parsing issues made the `lastModifiedTime` field optional.