### PR TITLE
Remove forDeploySACWithSourceAccount()

### DIFF
--- a/soroban.md
+++ b/soroban.md
@@ -1122,15 +1122,9 @@ Success!
 
 #### Deploying Stellar Asset Contract (SAC)
 
-The iOS SDK also provides support for deploying the build-in [Stellar Asset Contract](https://soroban.stellar.org/docs/built-in-contracts/stellar-asset-contract) (SAC). The following operations are available for this purpose:
+The iOS SDK provides support for deploying the built-in [Stellar Asset Contract](https://soroban.stellar.org/docs/built-in-contracts/stellar-asset-contract) (SAC).
 
-1. Deploy SAC with source account:
-
-```swift
-let operation = try InvokeHostFunctionOperation.forDeploySACWithSourceAccount(address: SCAddressXDR(accountId: accountId))
-```
-
-2. Deploy SAC with asset:
+Per [CAP-0046-06](https://stellar.org/protocol/cap-46-06), SAC deployment requires the `FROM_ASSET` preimage type. Use `forDeploySACWithAsset()`:
 
 ```swift
 let operation = try InvokeHostFunctionOperation.forDeploySACWithAsset(asset: asset)

--- a/stellarsdk/stellarsdk/sdk/InvokeHostFunctionOperation.swift
+++ b/stellarsdk/stellarsdk/sdk/InvokeHostFunctionOperation.swift
@@ -59,17 +59,6 @@ public class InvokeHostFunctionOperation:Operation {
         return InvokeHostFunctionOperation(hostFunction: hostFunction, sourceAccountId: sourceAccountId)
     }
 
-    /// Creates an operation to deploy a Stellar Asset Contract using a source account address.
-    public static func forDeploySACWithSourceAccount(address: SCAddressXDR, salt:WrappedData32? = nil, sourceAccountId:String? = nil) throws -> InvokeHostFunctionOperation {
-        let saltToSet = try salt ?? randomSalt()
-        let contractIdPreimageFormAddress = ContractIDPreimageFromAddressXDR(address: address, salt: saltToSet)
-        let contractIDPreimage = ContractIDPreimageXDR.fromAddress(contractIdPreimageFormAddress)
-        let executable = ContractExecutableXDR.token
-        let createContractArgs = CreateContractArgsXDR(contractIDPreimage: contractIDPreimage, executable: executable)
-        let hostFunction = HostFunctionXDR.createContract(createContractArgs)
-        return InvokeHostFunctionOperation(hostFunction: hostFunction, sourceAccountId: sourceAccountId)
-    }
-
     /// Creates an operation to deploy a Stellar Asset Contract for a specific asset.
     public static func forDeploySACWithAsset(asset:Asset, sourceAccountId:String? = nil) throws -> InvokeHostFunctionOperation {
         let contractIDPreimage = ContractIDPreimageXDR.fromAsset(try asset.toXDR())

--- a/stellarsdk/stellarsdkIntegrationTests/soroban/SorobanTest.swift
+++ b/stellarsdk/stellarsdkIntegrationTests/soroban/SorobanTest.swift
@@ -110,10 +110,6 @@ class SorobanTest: XCTestCase {
         // test contract data
         await getContractData()
 
-        // DISABLED: SAC deployment from address no longer works after protocol changes
-        // The combination CONTRACT_ID_PREIMAGE_FROM_ADDRESS + CONTRACT_EXECUTABLE_TOKEN is no longer accepted
-        // await deploySACWithSourceAccount()
-        
         // test SAC with asset
         await deploySACWithAsset()
         
@@ -750,90 +746,6 @@ class SorobanTest: XCTestCase {
         }
     }
     
-    // DISABLED: This test no longer works after protocol changes.
-    // The combination CONTRACT_ID_PREIMAGE_FROM_ADDRESS + CONTRACT_EXECUTABLE_TOKEN
-    // is no longer accepted by the network. Use deploySACWithAsset() instead.
-    /*
-    func deploySACWithSourceAccount() async {
-        await refreshSubmitterAccount()
-        
-        let deployOperation = try! InvokeHostFunctionOperation.forDeploySACWithSourceAccount(address: SCAddressXDR(accountId: submitterAccount!.accountId))
-        
-        let transaction = try! Transaction(sourceAccount: submitterAccount!,
-                                           operations: [deployOperation], memo: Memo.none)
-        let simulateTxRequest = SimulateTransactionRequest(transaction: transaction)
-        var simulateTxResponse:SimulateTransactionResponse? = nil
-        let simulateTxResponseEnum = await sorobanServer.simulateTransaction(simulateTxRequest: simulateTxRequest)
-        switch simulateTxResponseEnum {
-        case .success(let response):
-            simulateTxResponse = response
-        case .failure(let error):
-            self.printError(error: error)
-            XCTFail()
-        }
-        let simulateResponse = simulateTxResponse!
-        XCTAssertNotNil(simulateResponse.results)
-        XCTAssert(simulateResponse.results!.count > 0)
-        XCTAssertNotNil(simulateResponse.footprint)
-        XCTAssertNotNil(simulateResponse.transactionData)
-        XCTAssertNotNil(simulateResponse.minResourceFee)
-        
-        switch self.network {
-        case .futurenet:
-            XCTAssertNotNil(simulateResponse.stateChanges)
-            let stateChange = simulateResponse.stateChanges!.first
-            XCTAssertNotNil(stateChange!.after)
-        default:
-            break
-        }
-        
-        transaction.setSorobanTransactionData(data: simulateResponse.transactionData!)
-        transaction.addResourceFee(resourceFee: simulateResponse.minResourceFee!)
-        transaction.setSorobanAuth(auth: simulateResponse.sorobanAuth)
-        try! transaction.sign(keyPair: self.submitterKeyPair, network: self.network)
-        let deploySAFootprint = simulateResponse.footprint
-        XCTAssertNotNil(deploySAFootprint)
-        // check encoding and decoding
-        let enveloperXdr = try! transaction.encodedEnvelope();
-        XCTAssertEqual(enveloperXdr, try! Transaction(envelopeXdr: enveloperXdr).encodedEnvelope())
-        
-        var deploySATransactionId:String? = nil
-        let sendTxResponseEnum = await sorobanServer.sendTransaction(transaction: transaction)
-        switch sendTxResponseEnum {
-        case .success(let response):
-            XCTAssertNotEqual(SendTransactionResponse.STATUS_ERROR, response.status)
-            deploySATransactionId = response.transactionId
-        case .failure(let error):
-            self.printError(error: error)
-            XCTFail()
-        }
-        
-        // wait a couple of seconds before checking the status
-        try! await Task.sleep(nanoseconds: UInt64(10 * Double(NSEC_PER_SEC)))
-        let statusResponseEnum = await sorobanServer.getTransaction(transactionHash: deploySATransactionId!)
-        switch statusResponseEnum {
-        case .success(let statusResponse):
-            XCTAssertEqual(GetTransactionResponse.STATUS_SUCCESS, statusResponse.status)
-        case .failure(let error):
-            self.printError(error: error)
-            XCTFail()
-        }
-        
-        // get ledger entries
-        let contractDataKey = deploySAFootprint!.contractDataLedgerKey
-        let responseEnum = await sorobanServer.getLedgerEntries(base64EncodedKeys:[contractDataKey!])
-        switch responseEnum {
-        case .success(let response):
-            XCTAssert(Int(exactly: response.latestLedger)! > 0)
-        case .failure(let error):
-            self.printError(error: error)
-            XCTFail()
-        }
-        
-        await getTransactionDetails(transactionHash: deploySATransactionId!, type:"HostFunctionTypeHostFunctionTypeCreateContract", delaySec: 10.0)
-    }
-    */
-
     func deploySACWithAsset() async {
         await refreshSubmitterAccount()
         


### PR DESCRIPTION
## Summary

`forDeploySACWithSourceAccount(address:salt:)` uses the `FROM_ADDRESS` + `TOKEN` combination for SAC deployment, which the network no longer accepts. Transactions built with this function silently fail: they return `PENDING` on submission, then `NOT_FOUND` when polled.

Per [CAP-0046-06](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0046-06.md), SAC deployment requires the `FROM_ASSET` preimage type. The official Stellar SDKs (Go, JS) never had this function.

## Changes

- Removed `forDeploySACWithSourceAccount(address:salt:sourceAccountId:)` from `InvokeHostFunctionOperation.swift`
- Removed `deploySACWithSourceAccount()` integration test from `SorobanTest.swift`
- Updated `soroban.md` SAC deployment section to reference CAP-0046-06 and the valid `forDeploySACWithAsset()` function

## Test plan

- [x] Unit tests pass (3195 tests, 0 failures)
- [x] No remaining references to removed function in tracked files
- [x] Coverage at 85.51%