### PR TITLE
Security hardening and input validation fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@5d0cc745cd0cce4c0e9e0b3511de26c3bc285eb5 # v1
+        uses: anthropics/claude-code-action@e7b588b6eaa5263c2e7c6c7b34a29e190d32ee68 # v1.0.81
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  id-token: write
 
 concurrency:
   group: claude-review-${{ github.event.issue.number || github.event.pull_request.number }}
@@ -30,10 +29,10 @@ jobs:
        contains(fromJSON(vars.CLAUDE_ALLOWED_USERS), github.event.comment.user.login))
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@5d0cc745cd0cce4c0e9e0b3511de26c3bc285eb5 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
             -format=lcov > coverage/lcov.info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5 (pinned 2026-03-13)
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/lcov.info

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,17 +6,15 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     runs-on: macos-15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '16.2'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run unit tests with coverage
         run: |
@@ -39,7 +37,7 @@ jobs:
             -format=lcov > coverage/lcov.info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5 (pinned 2026-03-13)
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/lcov.info

--- a/.github/workflows/xdr-generator.yml
+++ b/.github/workflows/xdr-generator.yml
@@ -14,12 +14,15 @@ on:
       - 'xdr/*.x'
       - 'stellarsdk/stellarsdk/responses/xdr/**'
 
+permissions:
+  contents: read
+
 jobs:
   snapshot-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run generator snapshot tests
         run: make xdr-generator-test
@@ -28,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Regenerate XDR files
         run: make xdr-generate

--- a/.github/workflows/xdr-update-check.yml
+++ b/.github/workflows/xdr-update-check.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Clone upstream stellar-xdr (curr branch)
         id: clone

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ coverage/
 # Claude Code
 .claude/
 
+# Security reports
+sec-report*.md
+
 # XDR generator
 tools/xdr-generator/.bundle/
 tools/xdr-generator/vendor/

--- a/stellarsdk/stellarsdk/extensions/Dictionary+HttpParams.swift
+++ b/stellarsdk/stellarsdk/extensions/Dictionary+HttpParams.swift
@@ -26,12 +26,16 @@ extension Dictionary {
     ///
     /// See: [RFC 3986](http://www.ietf.org/rfc/rfc3986.txt) for URL encoding specification.
     func stringFromHttpParameters() -> String? {
-        let parameterArray = map { key, value -> String in
-            guard let key = key as? String else { return "" }
-            guard let value = value as? String else { return "" }
-            return "\(key)=\(value)"
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: "&=+")
+        let parameterArray = compactMap { key, value -> String? in
+            guard let key = key as? String, let value = value as? String else { return nil }
+            guard let encodedKey = key.addingPercentEncoding(withAllowedCharacters: allowed),
+                  let encodedValue = value.addingPercentEncoding(withAllowedCharacters: allowed)
+            else { return nil }
+            return "\(encodedKey)=\(encodedValue)"
         }
-        return parameterArray.filter{$0.count > 0}.joined(separator: "&").addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        return parameterArray.joined(separator: "&")
     }
     
 }

--- a/stellarsdk/stellarsdk/extensions/String+Encoding.swift
+++ b/stellarsdk/stellarsdk/extensions/String+Encoding.swift
@@ -10,6 +10,18 @@ import Foundation
 
 /// Extension providing encoding utilities for String.
 public extension String {
+    var urlPathEncoded: String {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "/&=;+")
+        return self.addingPercentEncoding(withAllowedCharacters: allowed) ?? self
+    }
+
+    var urlQueryValueEncoded: String {
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: "&=+")
+        return self.addingPercentEncoding(withAllowedCharacters: allowed) ?? self
+    }
+
     /// URL-encodes the string for use in query parameters.
     ///
     /// Encodes characters that are not allowed in URL query parameters and keys.

--- a/stellarsdk/stellarsdk/federation/Federation.swift
+++ b/stellarsdk/stellarsdk/federation/Federation.swift
@@ -143,7 +143,7 @@ public final class Federation: @unchecked Sendable {
             return .failure(error: .invalidAddress)
         }
         
-        let requestPath = "?q=\(address)&type=name"
+        let requestPath = "?q=\(address.urlQueryValueEncoded)&type=name"
         
         let result = await serviceHelper.GETRequestWithPath(path: requestPath)
         switch result {
@@ -174,7 +174,7 @@ public final class Federation: @unchecked Sendable {
             return .failure(error: .invalidAccountId)
         }
         
-        let requestPath = "?q=\(account_id)&type=id"
+        let requestPath = "?q=\(account_id.urlQueryValueEncoded)&type=id"
         
         let result = await serviceHelper.GETRequestWithPath(path: requestPath)
         switch result {
@@ -198,7 +198,7 @@ public final class Federation: @unchecked Sendable {
     /// - Parameter transaction_id: The transaction hash/ID
     /// - Returns: ResolveResponseEnum with federation data, or an error
     public func resolve(transaction_id: String) async -> ResolveResponseEnum {
-        let requestPath = "?q=\(transaction_id)&type=txid"
+        let requestPath = "?q=\(transaction_id.urlQueryValueEncoded)&type=txid"
         
         let result = await serviceHelper.GETRequestWithPath(path: requestPath)
         switch result {

--- a/stellarsdk/stellarsdk/interactive/InteractiveService.swift
+++ b/stellarsdk/stellarsdk/interactive/InteractiveService.swift
@@ -272,7 +272,7 @@ public final class InteractiveService: @unchecked Sendable {
     public func info(language: String? = nil) async -> Sep24InfoResponseEnum {
         var requestPath = "/info"
         if let language = language {
-            requestPath += "?lang=\(language)"
+            requestPath += "?lang=\(language.urlQueryValueEncoded)"
         }
         
         let result = await serviceHelper.GETRequestWithPath(path: requestPath)
@@ -299,10 +299,10 @@ public final class InteractiveService: @unchecked Sendable {
     /// - Parameter request: Sep24FeeRequest containing operation type, asset code, amount, and JWT token
     /// - Returns: Sep24FeeResponseEnum with fee amount, or an error
     public func fee(request: Sep24FeeRequest) async -> Sep24FeeResponseEnum {
-        var requestPath = "/fee?operation=\(request.operation)&asset_code=\(request.assetCode)&amount=\(request.amount)"
-        
+        var requestPath = "/fee?operation=\(request.operation.urlQueryValueEncoded)&asset_code=\(request.assetCode.urlQueryValueEncoded)&amount=\(String(request.amount).urlQueryValueEncoded)"
+
         if let type = request.type {
-            requestPath += "&type=\(type)"
+            requestPath += "&type=\(type.urlQueryValueEncoded)"
         }
         
         let result = await serviceHelper.GETRequestWithPath(path: requestPath, jwtToken: request.jwt)
@@ -373,22 +373,22 @@ public final class InteractiveService: @unchecked Sendable {
     /// - Parameter request: Sep24TransactionsRequest containing asset code, filters, pagination options, and JWT token
     /// - Returns: Sep24TransactionsResponseEnum with list of transactions, or an error
     public func getTransactions(request: Sep24TransactionsRequest) async -> Sep24TransactionsResponseEnum {
-        var requestPath = "/transactions?asset_code=\(request.assetCode)"
+        var requestPath = "/transactions?asset_code=\(request.assetCode.urlQueryValueEncoded)"
         if let noOlderThanDate = request.noOlderThan {
             let noOlderThan = DateFormatter.iso8601.string(from: noOlderThanDate)
-            requestPath += "&no_older_than=\(noOlderThan)"
+            requestPath += "&no_older_than=\(noOlderThan.urlQueryValueEncoded)"
         }
         if let limit = request.limit {
             requestPath += "&limit=\(limit)"
         }
         if let kind = request.kind {
-            requestPath += "&kind=\(kind)"
+            requestPath += "&kind=\(kind.urlQueryValueEncoded)"
         }
         if let pagingId = request.pagingId {
-            requestPath += "&paging_id=\(pagingId)"
+            requestPath += "&paging_id=\(pagingId.urlQueryValueEncoded)"
         }
         if let lang = request.lang {
-            requestPath += "&lang=\(lang)"
+            requestPath += "&lang=\(lang.urlQueryValueEncoded)"
         }
         
         let result = await serviceHelper.GETRequestWithPath(path: requestPath, jwtToken: request.jwt)
@@ -414,30 +414,30 @@ public final class InteractiveService: @unchecked Sendable {
     /// - Returns: Sep24TransactionResponseEnum with transaction details and status, or an error
     public func getTransaction(request: Sep24TransactionRequest) async -> Sep24TransactionResponseEnum {
         var requestPath = "/transaction?"
-        
+
         var first = true
         if let id = request.id {
-            requestPath += "id=\(id)"
+            requestPath += "id=\(id.urlQueryValueEncoded)"
             first = false
         }
         if let stellarTransactionId = request.stellarTransactionId {
             if !first {
                 requestPath += "&"
             }
-            requestPath += "stellar_transaction_id=\(stellarTransactionId)"
+            requestPath += "stellar_transaction_id=\(stellarTransactionId.urlQueryValueEncoded)"
             first = false
         }
         if let externalTransactionId = request.externalTransactionId {
             if !first {
                 requestPath += "&"
             }
-            requestPath += "external_transaction_id=\(externalTransactionId)"
+            requestPath += "external_transaction_id=\(externalTransactionId.urlQueryValueEncoded)"
         }
         if let lang = request.lang {
             if !first {
                 requestPath += "&"
             }
-            requestPath += "lang=\(lang)"
+            requestPath += "lang=\(lang.urlQueryValueEncoded)"
         }
         
         let result = await serviceHelper.GETRequestWithPath(path: requestPath, jwtToken: request.jwt)

--- a/stellarsdk/stellarsdk/kyc/KycService.swift
+++ b/stellarsdk/stellarsdk/kyc/KycService.swift
@@ -325,27 +325,27 @@ public final class KycService: @unchecked Sendable {
     /// See: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-get
     public func getCustomerInfo(request: GetCustomerInfoRequest) async -> GetCustomerInfoResponseEnum {
         var requestPath = "/customer"
-        
+
         if let id = request.id {
-            requestPath += "&id=\(id)"
+            requestPath += "&id=\(id.urlQueryValueEncoded)"
         }
         if let account = request.account {
-            requestPath += "&account=\(account)"
+            requestPath += "&account=\(account.urlQueryValueEncoded)"
         }
         if let memo = request.memo {
-            requestPath += "&memo=\(memo)"
+            requestPath += "&memo=\(memo.urlQueryValueEncoded)"
         }
         if let memoType = request.memoType {
-            requestPath += "&memo_type=\(memoType)"
+            requestPath += "&memo_type=\(memoType.urlQueryValueEncoded)"
         }
         if let type = request.type {
-            requestPath += "&type=\(type)"
+            requestPath += "&type=\(type.urlQueryValueEncoded)"
         }
         if let transactionId = request.transactionId {
-            requestPath += "&transaction_id=\(transactionId)"
+            requestPath += "&transaction_id=\(transactionId.urlQueryValueEncoded)"
         }
         if let lang = request.lang {
-            requestPath += "&lang=\(lang)"
+            requestPath += "&lang=\(lang.urlQueryValueEncoded)"
         }
         
         if let range = requestPath.range(of: "&") {
@@ -425,7 +425,7 @@ public final class KycService: @unchecked Sendable {
     /// - Parameter jwt: JWT token from SEP-10 authentication
     /// - Returns: DeleteCustomerResponseEnum indicating success or an error
     public func deleteCustomerInfo(account: String, jwt:String) async -> DeleteCustomerResponseEnum {
-        let requestPath = "/customer/\(account)"
+        let requestPath = "/customer/\(account.urlPathEncoded)"
         
         let result = await serviceHelper.DELETERequestWithPath(path: requestPath, jwtToken: jwt)
         switch result {
@@ -501,12 +501,12 @@ public final class KycService: @unchecked Sendable {
     /// See: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-files
     public func getCustomerFiles(fileId:String? = nil, customerId:String? = nil, jwtToken: String) async -> GetCustomerFilesResponseEnum {
         var requestPath = "/customer/files"
-        
+
         if let fid = fileId {
-            requestPath += "&file_id=\(fid)"
+            requestPath += "&file_id=\(fid.urlQueryValueEncoded)"
         }
         if let cid = customerId {
-            requestPath += "&customer_id=\(cid)"
+            requestPath += "&customer_id=\(cid.urlQueryValueEncoded)"
         }
         
         if let range = requestPath.range(of: "&") {

--- a/stellarsdk/stellarsdk/quote/QuoteService.swift
+++ b/stellarsdk/stellarsdk/quote/QuoteService.swift
@@ -143,15 +143,15 @@ public final class QuoteService: @unchecked Sendable {
                        countryCode:String? = nil,
                        jwt:String? = nil) async -> Sep38PricesResponseEnum {
         
-        var requestPath = "/prices?sell_asset=\(sellAsset)&sell_amount=\(sellAmount)"
+        var requestPath = "/prices?sell_asset=\(sellAsset.urlQueryValueEncoded)&sell_amount=\(sellAmount.urlQueryValueEncoded)"
         if let value = sellDeliveryMethod {
-            requestPath += "&sell_delivery_method=\(value)"
+            requestPath += "&sell_delivery_method=\(value.urlQueryValueEncoded)"
         }
         if let value = buyDeliveryMethod {
-            requestPath += "&buy_delivery_method=\(value)"
+            requestPath += "&buy_delivery_method=\(value.urlQueryValueEncoded)"
         }
         if let value = countryCode {
-            requestPath += "&country_code=\(value)"
+            requestPath += "&country_code=\(value.urlQueryValueEncoded)"
         }
         
         let result = await serviceHelper.GETRequestWithPath(path: requestPath, jwtToken: jwt)
@@ -199,21 +199,21 @@ public final class QuoteService: @unchecked Sendable {
             return .failure(error: .invalidArgument(message: "The caller must provide either sellAmount or buyAmount, but not both"))
         }
         
-        var requestPath = "/price?sell_asset=\(sellAsset)&buy_asset=\(buyAsset)&context=\(context)"
+        var requestPath = "/price?sell_asset=\(sellAsset.urlQueryValueEncoded)&buy_asset=\(buyAsset.urlQueryValueEncoded)&context=\(context.urlQueryValueEncoded)"
         if let value = sellAmount {
-            requestPath += "&sell_amount=\(value)"
+            requestPath += "&sell_amount=\(value.urlQueryValueEncoded)"
         }
         if let value = buyAmount {
-            requestPath += "&buy_amount=\(value)"
+            requestPath += "&buy_amount=\(value.urlQueryValueEncoded)"
         }
         if let value = sellDeliveryMethod {
-            requestPath += "&sell_delivery_method=\(value)"
+            requestPath += "&sell_delivery_method=\(value.urlQueryValueEncoded)"
         }
         if let value = buyDeliveryMethod {
-            requestPath += "&buy_delivery_method=\(value)"
+            requestPath += "&buy_delivery_method=\(value.urlQueryValueEncoded)"
         }
         if let value = countryCode {
-            requestPath += "&country_code=\(value)"
+            requestPath += "&country_code=\(value.urlQueryValueEncoded)"
         }
         
         let result = await serviceHelper.GETRequestWithPath(path: requestPath, jwtToken: jwt)
@@ -274,7 +274,7 @@ public final class QuoteService: @unchecked Sendable {
     /// See: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#get-quote
     public func getQuote(id:String, jwt:String? = nil) async -> Sep38QuoteResponseEnum {
         
-        let requestPath = "/quote/\(id)"
+        let requestPath = "/quote/\(id.urlPathEncoded)"
         
         let result = await serviceHelper.GETRequestWithPath(path: requestPath, jwtToken: jwt)
         switch result {

--- a/stellarsdk/stellarsdk/sdk/ChangeTrustOperation.swift
+++ b/stellarsdk/stellarsdk/sdk/ChangeTrustOperation.swift
@@ -44,7 +44,7 @@ public class ChangeTrustOperation:Operation, @unchecked Sendable {
         let assetXDR = try asset.toChangeTrustAssetXDR()
         let limitXDR: Int64
         if let limit = limit {
-            limitXDR = Operation.toXDRAmount(amount: limit)
+            limitXDR = try Operation.toXDRAmount(amount: limit)
         } else {
             limitXDR = Int64.max
         }

--- a/stellarsdk/stellarsdk/sdk/ClawbackOperation.swift
+++ b/stellarsdk/stellarsdk/sdk/ClawbackOperation.swift
@@ -48,7 +48,7 @@ public class ClawbackOperation:Operation, @unchecked Sendable {
     
     override func getOperationBodyXDR() throws -> OperationBodyXDR {
         let assetXDR = try asset.toXDR()
-        let amountXDR = Operation.toXDRAmount(amount: amount)
+        let amountXDR = try Operation.toXDRAmount(amount: amount)
         let fromXDR = try fromAccountId.decodeMuxedAccount()
     
         return OperationBodyXDR.clawbackOp(ClawbackOpXDR(asset: assetXDR, from: fromXDR, amount: amountXDR))

--- a/stellarsdk/stellarsdk/sdk/CreateAccountOperation.swift
+++ b/stellarsdk/stellarsdk/sdk/CreateAccountOperation.swift
@@ -88,6 +88,6 @@ public class CreateAccountOperation:Operation, @unchecked Sendable {
     
     override func getOperationBodyXDR() throws -> OperationBodyXDR {
         return OperationBodyXDR.createAccountOp(CreateAccountOperationXDR(destination: destination.publicKey,
-                                                                        balance: Operation.toXDRAmount(amount: startBalance)))
+                                                                        balance: try Operation.toXDRAmount(amount: startBalance)))
     }
 }

--- a/stellarsdk/stellarsdk/sdk/CreateClaimableBalanceOperation.swift
+++ b/stellarsdk/stellarsdk/sdk/CreateClaimableBalanceOperation.swift
@@ -53,7 +53,7 @@ public class CreateClaimableBalanceOperation:Operation, @unchecked Sendable {
         for claimant in claimants {
             claimantsXDRArray.append(try claimant.toXDR())
         }
-        let amountXDR = Operation.toXDRAmount(amount: amount)
+        let amountXDR = try Operation.toXDRAmount(amount: amount)
         let cbXDR = CreateClaimableBalanceOpXDR(asset: assetXDR, amount: amountXDR, claimants: claimantsXDRArray)
         return OperationBodyXDR.createClaimableBalanceOp(cbXDR)
     }

--- a/stellarsdk/stellarsdk/sdk/CreatePassiveOfferOperation.swift
+++ b/stellarsdk/stellarsdk/sdk/CreatePassiveOfferOperation.swift
@@ -54,7 +54,7 @@ public class CreatePassiveOfferOperation:Operation, @unchecked Sendable {
     override func getOperationBodyXDR() throws -> OperationBodyXDR {
         let sellingXDR = try selling.toXDR()
         let buyingXDR = try buying.toXDR()
-        let amountXDR = Operation.toXDRAmount(amount: amount)
+        let amountXDR = try Operation.toXDRAmount(amount: amount)
         let priceXDR = price.toXdr()
         
         return OperationBodyXDR.createPassiveSellOfferOp(CreatePassiveOfferOperationXDR(selling: sellingXDR,

--- a/stellarsdk/stellarsdk/sdk/LiquidityPoolDepositOperation.swift
+++ b/stellarsdk/stellarsdk/sdk/LiquidityPoolDepositOperation.swift
@@ -60,8 +60,8 @@ public class LiquidityPoolDepositOperation:Operation, @unchecked Sendable {
     }
     
     override func getOperationBodyXDR() throws -> OperationBodyXDR {
-        let maxAmountAXDR = Operation.toXDRAmount(amount: maxAmountA)
-        let maxAmountBXDR = Operation.toXDRAmount(amount: maxAmountB)
+        let maxAmountAXDR = try Operation.toXDRAmount(amount: maxAmountA)
+        let maxAmountBXDR = try Operation.toXDRAmount(amount: maxAmountB)
         return try OperationBodyXDR.liquidityPoolDepositOp(
             LiquidityPoolDepositOpXDR(liquidityPoolId:liquidityPoolId,
                                       maxAmountA: maxAmountAXDR,

--- a/stellarsdk/stellarsdk/sdk/LiquidityPoolWithdrawOperation.swift
+++ b/stellarsdk/stellarsdk/sdk/LiquidityPoolWithdrawOperation.swift
@@ -54,8 +54,8 @@ public class LiquidityPoolWithdrawOperation:Operation, @unchecked Sendable {
     override func getOperationBodyXDR() throws -> OperationBodyXDR {
         return try OperationBodyXDR.liquidityPoolWithdrawOp(
             LiquidityPoolWithdrawOpXDR(liquidityPoolId:liquidityPoolId,
-                                       amount: Operation.toXDRAmount(amount:amount),
-                                       minAmountA: Operation.toXDRAmount(amount:minAmountA),
-                                       minAmountB: Operation.toXDRAmount(amount:minAmountB)))
+                                       amount: try Operation.toXDRAmount(amount:amount),
+                                       minAmountA: try Operation.toXDRAmount(amount:minAmountA),
+                                       minAmountB: try Operation.toXDRAmount(amount:minAmountB)))
     }
 }

--- a/stellarsdk/stellarsdk/sdk/ManageBuyOfferOperation.swift
+++ b/stellarsdk/stellarsdk/sdk/ManageBuyOfferOperation.swift
@@ -35,7 +35,7 @@ public class ManageBuyOfferOperation:ManageOfferOperation, @unchecked Sendable {
     override func getOperationBodyXDR() throws -> OperationBodyXDR {
         let sellingXDR = try selling.toXDR()
         let buyingXDR = try buying.toXDR()
-        let amountXDR = Operation.toXDRAmount(amount: amount)
+        let amountXDR = try Operation.toXDRAmount(amount: amount)
         let priceXDR = price.toXdr()
         
         return OperationBodyXDR.manageBuyOfferOp(ManageOfferOperationXDR(selling: sellingXDR,

--- a/stellarsdk/stellarsdk/sdk/ManageOfferOperation.swift
+++ b/stellarsdk/stellarsdk/sdk/ManageOfferOperation.swift
@@ -57,7 +57,7 @@ public class ManageOfferOperation:Operation, @unchecked Sendable {
     override func getOperationBodyXDR() throws -> OperationBodyXDR {
         let sellingXDR = try selling.toXDR()
         let buyingXDR = try buying.toXDR()
-        let amountXDR = Operation.toXDRAmount(amount: amount)
+        let amountXDR = try Operation.toXDRAmount(amount: amount)
         let priceXDR = price.toXdr()
         
         return OperationBodyXDR.manageSellOfferOp(ManageOfferOperationXDR(selling: sellingXDR,

--- a/stellarsdk/stellarsdk/sdk/Memo.swift
+++ b/stellarsdk/stellarsdk/sdk/Memo.swift
@@ -50,8 +50,8 @@ extension Memo: MemoProtocol {
     /// - Throws an StellarSDKError.invalidArgument error if the given string is larger than 28 bytes.
     ///
     public init?(text:String) throws {
-        if text.count > StellarProtocolConstants.MEMO_TEXT_MAX_LENGTH {
-            throw StellarSDKError.invalidArgument(message: "text must be <= \(StellarProtocolConstants.MEMO_TEXT_MAX_LENGTH) bytes. length=\(text.count)" )
+        if text.utf8.count > StellarProtocolConstants.MEMO_TEXT_MAX_LENGTH {
+            throw StellarSDKError.invalidArgument(message: "text must be <= \(StellarProtocolConstants.MEMO_TEXT_MAX_LENGTH) bytes. length=\(text.utf8.count)" )
         }
         self = .text(text)
     }

--- a/stellarsdk/stellarsdk/sdk/Operation.swift
+++ b/stellarsdk/stellarsdk/sdk/Operation.swift
@@ -161,12 +161,19 @@ public class Operation: @unchecked Sendable {
         throw StellarSDKError.invalidArgument(message: "Method must be overridden by subclass")
     }
     
-    static func toXDRAmount(amount:Decimal) -> Int64 {
+    static func toXDRAmount(amount:Decimal) throws -> Int64 {
+        guard amount >= 0 else {
+            throw StellarSDKError.invalidArgument(message: "Amount must be non-negative, got: \(amount)")
+        }
         let multiplied = amount * 10000000
+        let maxStroops = Decimal(Int64.max)
+        guard multiplied <= maxStroops else {
+            throw StellarSDKError.invalidArgument(message: "Amount too large, exceeds Int64 range: \(amount)")
+        }
         let decimalNumber = NSDecimalNumber(decimal: multiplied)
-        let handler = NSDecimalNumberHandler(roundingMode: NSDecimalNumber.RoundingMode.bankers, scale: 0, raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false)
+        let handler = NSDecimalNumberHandler(roundingMode: NSDecimalNumber.RoundingMode.bankers, scale: 0, raiseOnExactness: false, raiseOnOverflow: true, raiseOnUnderflow: false, raiseOnDivideByZero: false)
         let rounded = decimalNumber.rounding(accordingToBehavior: handler)
-        
+
         return rounded.int64Value
     }
     

--- a/stellarsdk/stellarsdk/sdk/PathPaymentOperation.swift
+++ b/stellarsdk/stellarsdk/sdk/PathPaymentOperation.swift
@@ -81,8 +81,8 @@ public class PathPaymentOperation:Operation, @unchecked Sendable {
             try pathXDR.append(asset.toXDR())
         }
         
-        let sendMaxXDR = Operation.toXDRAmount(amount: sendMax)
-        let destAmountXDR = Operation.toXDRAmount(amount: destAmount)
+        let sendMaxXDR = try Operation.toXDRAmount(amount: sendMax)
+        let destAmountXDR = try Operation.toXDRAmount(amount: destAmount)
         let mDestination = try destinationAccountId.decodeMuxedAccount()
         
         return OperationBodyXDR.pathPaymentStrictReceiveOp(PathPaymentOperationXDR(sendAsset: sendAssetXDR,

--- a/stellarsdk/stellarsdk/sdk/PathPaymentStrictSendOperation.swift
+++ b/stellarsdk/stellarsdk/sdk/PathPaymentStrictSendOperation.swift
@@ -32,8 +32,8 @@ public class PathPaymentStrictSendOperation:PathPaymentOperation, @unchecked Sen
             try pathXDR.append(asset.toXDR())
         }
         
-        let sendMaxXDR = Operation.toXDRAmount(amount: sendMax)
-        let destAmountXDR = Operation.toXDRAmount(amount: destAmount)
+        let sendMaxXDR = try Operation.toXDRAmount(amount: sendMax)
+        let destAmountXDR = try Operation.toXDRAmount(amount: destAmount)
         let mDestination = try destinationAccountId.decodeMuxedAccount()
         
         return OperationBodyXDR.pathPaymentStrictSendOp(PathPaymentOperationXDR(sendAsset: sendAssetXDR,

--- a/stellarsdk/stellarsdk/sdk/PaymentOperation.swift
+++ b/stellarsdk/stellarsdk/sdk/PaymentOperation.swift
@@ -87,7 +87,7 @@ public class PaymentOperation:Operation, @unchecked Sendable {
     
     override func getOperationBodyXDR() throws -> OperationBodyXDR {
         let assetXDR = try asset.toXDR()
-        let xdrAmount = Operation.toXDRAmount(amount: amount)
+        let xdrAmount = try Operation.toXDRAmount(amount: amount)
         let mDestination = try destinationAccountId.decodeMuxedAccount()
         return OperationBodyXDR.paymentOp(PaymentOperationXDR(destination: mDestination,
                                                             asset:assetXDR,

--- a/stellarsdk/stellarsdk/service/AccountService.swift
+++ b/stellarsdk/stellarsdk/service/AccountService.swift
@@ -102,9 +102,9 @@ open class AccountService: @unchecked Sendable {
     /// See also:
     /// - [Stellar developer docs](https://developers.stellar.org)
     open func getAccountDetails(accountId: String) async -> AccountResponseEnum {
-        var requestPath = "/accounts/\(accountId)"
+        var requestPath = "/accounts/\(accountId.urlPathEncoded)"
         if accountId.hasPrefix("M"), let mux = try? accountId.decodeMuxedAccount() {
-            requestPath = "/accounts/\(mux.ed25519AccountId)"
+            requestPath = "/accounts/\(mux.ed25519AccountId.urlPathEncoded)"
         }
         let result = await serviceHelper.GETRequestWithPath(path: requestPath)
         switch result {
@@ -154,7 +154,7 @@ open class AccountService: @unchecked Sendable {
     /// - [Stellar developer docs](https://developers.stellar.org)
     /// - ManageDataOperation for setting account data
     open func getDataForAccount(accountId: String, key: String) async -> DataForAccountResponseEnum {
-        let requestPath = "/accounts/\(accountId)/data/\(key)"
+        let requestPath = "/accounts/\(accountId.urlPathEncoded)/data/\(key.urlPathEncoded)"
         
         let result = await serviceHelper.GETRequestWithPath(path: requestPath)
         switch result {
@@ -412,9 +412,9 @@ open class AccountService: @unchecked Sendable {
     /// - AccountStreamItem for stream control methods
     /// - AccountResponse for the account data structure
     open func streamAccount(accountId: String) -> AccountStreamItem {
-        var requestPath = "/accounts/\(accountId)"
+        var requestPath = "/accounts/\(accountId.urlPathEncoded)"
         if accountId.hasPrefix("M"), let mux = try? accountId.decodeMuxedAccount() {
-            requestPath = "/accounts/\(mux.ed25519AccountId)"
+            requestPath = "/accounts/\(mux.ed25519AccountId.urlPathEncoded)"
         }
         let streamUrl = serviceHelper.requestUrlWithPath(path: requestPath)
         return AccountStreamItem(requestUrl: streamUrl)
@@ -469,7 +469,7 @@ open class AccountService: @unchecked Sendable {
     /// - DataForAccountResponse for the data entry structure
     /// - ManageDataOperation for setting account data
     open func streamAccountData(accountId: String, key: String) -> AccountDataStreamItem {
-        let requestPath = "/accounts/\(accountId)/data/\(key)"
+        let requestPath = "/accounts/\(accountId.urlPathEncoded)/data/\(key.urlPathEncoded)"
         let streamUrl = serviceHelper.requestUrlWithPath(path: requestPath)
         return AccountDataStreamItem(requestUrl: streamUrl)
     }

--- a/stellarsdk/stellarsdk/service/ClaimableBalancesService.swift
+++ b/stellarsdk/stellarsdk/service/ClaimableBalancesService.swift
@@ -68,7 +68,7 @@ public class ClaimableBalancesService: @unchecked Sendable {
             let cid = try? balanceId.decodeClaimableBalanceIdToHex() {
             idHex = cid
         }
-        let requestPath = "/claimable_balances/" + idHex
+        let requestPath = "/claimable_balances/" + idHex.urlPathEncoded
         let result = await serviceHelper.GETRequestWithPath(path: requestPath)
         switch result {
         case .success(let data):

--- a/stellarsdk/stellarsdk/service/EffectsService.swift
+++ b/stellarsdk/stellarsdk/service/EffectsService.swift
@@ -96,7 +96,7 @@ public class EffectsService: @unchecked Sendable {
     ///
     /// See: [Stellar developer docs](https://developers.stellar.org)
     open func getEffects(forAccount accountId:String, from cursor:String? = nil, order:Order? = nil, limit:Int? = nil) async -> PageResponse<EffectResponse>.ResponseEnum {
-        let path = "/accounts/" + accountId + "/effects"
+        let path = "/accounts/" + accountId.urlPathEncoded + "/effects"
         return await getEffects(onPath: path, from:cursor, order:order, limit:limit)
     }
     
@@ -114,7 +114,7 @@ public class EffectsService: @unchecked Sendable {
     ///
     /// See: [Stellar developer docs](https://developers.stellar.org)
     open func getEffects(forLedger ledger:String, from cursor:String? = nil, order:Order? = nil, limit:Int? = nil) async -> PageResponse<EffectResponse>.ResponseEnum {
-        let path = "/ledgers/" + ledger + "/effects"
+        let path = "/ledgers/" + ledger.urlPathEncoded + "/effects"
         return await getEffects(onPath: path, from:cursor, order:order, limit:limit)
     }
     
@@ -131,7 +131,7 @@ public class EffectsService: @unchecked Sendable {
     ///
     /// See: [Stellar developer docs](https://developers.stellar.org)
     open func getEffects(forOperation operation:String, from cursor:String? = nil, order:Order? = nil, limit:Int? = nil) async -> PageResponse<EffectResponse>.ResponseEnum {
-        let path = "/operations/" + operation + "/effects"
+        let path = "/operations/" + operation.urlPathEncoded + "/effects"
         return await getEffects(onPath: path, from:cursor, order:order, limit:limit)
     }
     
@@ -148,7 +148,7 @@ public class EffectsService: @unchecked Sendable {
     ///
     /// See: [Stellar developer docs](https://developers.stellar.org)
     open func getEffects(forTransaction hash:String, from cursor:String? = nil, order:Order? = nil, limit:Int? = nil) async -> PageResponse<EffectResponse>.ResponseEnum {
-        let path = "/transactions/" + hash + "/effects"
+        let path = "/transactions/" + hash.urlPathEncoded + "/effects"
         return await getEffects(onPath: path, from:cursor, order:order, limit:limit)
     }
     
@@ -164,7 +164,7 @@ public class EffectsService: @unchecked Sendable {
         if liquidityPoolId.hasPrefix("L"), let idHex = try? liquidityPoolId.decodeLiquidityPoolIdToHex() {
             lidHex = idHex
         }
-        let path = "/liquidity_pools/" + lidHex + "/effects"
+        let path = "/liquidity_pools/" + lidHex.urlPathEncoded + "/effects"
         return await getEffects(onPath: path, from:cursor, order:order, limit:limit)
     }
     
@@ -178,36 +178,36 @@ public class EffectsService: @unchecked Sendable {
         case .allEffects(let cursor):
             subpath = "/effects"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         case .effectsForAccount(let accountId, let cursor):
-            subpath = "/accounts/" + accountId + "/effects"
+            subpath = "/accounts/" + accountId.urlPathEncoded + "/effects"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         case .effectsForLedger(let ledger, let cursor):
-            subpath = "/ledgers/" + ledger + "/effects"
+            subpath = "/ledgers/" + ledger.urlPathEncoded + "/effects"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         case .effectsForOperation(let operation, let cursor):
-            subpath = "/operations/" + operation + "/effects"
+            subpath = "/operations/" + operation.urlPathEncoded + "/effects"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         case .effectsForTransaction(let transaction, let cursor):
-            subpath = "/transactions/" + transaction + "/effects"
+            subpath = "/transactions/" + transaction.urlPathEncoded + "/effects"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         case .effectsForLiquidityPool(let liquidityPool, let cursor):
             var lidHex = liquidityPool
             if liquidityPool.hasPrefix("L"), let idHex = try? liquidityPool.decodeLiquidityPoolIdToHex() {
                 lidHex = idHex
             }
-            subpath = "/liquidity_pools/" + lidHex + "/effects"
+            subpath = "/liquidity_pools/" + lidHex.urlPathEncoded + "/effects"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         }
         let streamItem = EffectsStreamItem(requestUrl: serviceHelper.requestUrlWithPath(path: subpath))

--- a/stellarsdk/stellarsdk/service/EffectsService.swift
+++ b/stellarsdk/stellarsdk/service/EffectsService.swift
@@ -248,7 +248,7 @@ public class EffectsService: @unchecked Sendable {
                 let effects = try self.effectsFactory.effectsFromResponseData(data: data)
                 return .success(page: effects)
             } catch {
-                return .failure(error: error as! HorizonRequestError)
+                return .failure(error: .parsingResponseFailed(message: error.localizedDescription))
             }
         case .failure(let error):
             return .failure(error:error)

--- a/stellarsdk/stellarsdk/service/LedgersService.swift
+++ b/stellarsdk/stellarsdk/service/LedgersService.swift
@@ -63,7 +63,7 @@ public class LedgersService: @unchecked Sendable {
     /// - Parameter sequenceNumber: The ledger sequence number as a string
     /// - Returns: LedgerDetailsResponseEnum with ledger details or error
     open func getLedger(sequenceNumber:String) async -> LedgerDetailsResponseEnum {
-        let requestPath = "/ledgers/" + sequenceNumber
+        let requestPath = "/ledgers/" + sequenceNumber.urlPathEncoded
         let result = await serviceHelper.GETRequestWithPath(path: requestPath)
         switch result {
         case .success(let data):
@@ -130,7 +130,7 @@ public class LedgersService: @unchecked Sendable {
         case .allLedgers(let cursor):
             subpath = "/ledgers"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         }
         

--- a/stellarsdk/stellarsdk/service/LiquidityPoolsService.swift
+++ b/stellarsdk/stellarsdk/service/LiquidityPoolsService.swift
@@ -74,7 +74,7 @@ public class LiquidityPoolsService: @unchecked Sendable {
         if poolId.hasPrefix("L"), let idHex = try? poolId.decodeLiquidityPoolIdToHex() {
             lidHex = idHex
         }
-        let requestPath = "/liquidity_pools/" + lidHex
+        let requestPath = "/liquidity_pools/" + lidHex.urlPathEncoded
         let result = await serviceHelper.GETRequestWithPath(path: requestPath)
         switch result {
         case .success(let data):
@@ -147,7 +147,7 @@ public class LiquidityPoolsService: @unchecked Sendable {
     /// - Parameter limit: Optional maximum number of records to return. Default: 10, max: 200
     /// - Returns: LiquidityPoolTradesResponseEnum with trade history or error
     open func getLiquidityPoolTrades(poolId:String, cursor:String? = nil, order:Order? = nil, limit:Int? = nil) async -> LiquidityPoolTradesResponseEnum {
-        var requestPath = "/liquidity_pools/" + poolId + "/trades"
+        var requestPath = "/liquidity_pools/" + poolId.urlPathEncoded + "/trades"
 
         var params = Dictionary<String,String>()
         params["cursor"] = cursor
@@ -207,7 +207,7 @@ public class LiquidityPoolsService: @unchecked Sendable {
         if poolId.hasPrefix("L"), let idHex = try? poolId.decodeLiquidityPoolIdToHex() {
             lidHex = idHex
         }
-        let requestPath = "/liquidity_pools/" + lidHex + "/trades"
+        let requestPath = "/liquidity_pools/" + lidHex.urlPathEncoded + "/trades"
         let streamUrl = serviceHelper.requestUrlWithPath(path: requestPath)
         return LiquidityPoolTradesStreamItem(requestUrl: streamUrl)
     }

--- a/stellarsdk/stellarsdk/service/OffersService.swift
+++ b/stellarsdk/stellarsdk/service/OffersService.swift
@@ -80,7 +80,7 @@ public class OffersService: @unchecked Sendable {
     /// - Parameter limit: Optional maximum number of records to return. Default: 10, max: 200
     /// - Returns: PageResponse containing offers for the account or error
     open func getOffers(forAccount accountId:String, cursor:String? = nil, order:Order? = nil, limit:Int? = nil) async -> PageResponse<OfferResponse>.ResponseEnum {
-        var requestPath = "/accounts/" + accountId + "/offers"
+        var requestPath = "/accounts/" + accountId.urlPathEncoded + "/offers"
         
         var params = Dictionary<String,String>()
         params["cursor"] = cursor
@@ -199,9 +199,9 @@ public class OffersService: @unchecked Sendable {
 
         case .offersForAccount(let accountId,
                                let cursor):
-            subpath = "/accounts/" + accountId + "/offers"
+            subpath = "/accounts/" + accountId.urlPathEncoded + "/offers"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         }
 
@@ -217,7 +217,7 @@ public class OffersService: @unchecked Sendable {
     /// - Parameter limit: Optional maximum number of records to return
     /// - Returns: TradesStreamItem for receiving streaming trade updates
     open func streamTrades(forOffer offerId: String, cursor: String? = nil, order: Order? = nil, limit: Int? = nil) -> TradesStreamItem {
-        var requestPath = "/offers/" + offerId + "/trades"
+        var requestPath = "/offers/" + offerId.urlPathEncoded + "/trades"
 
         var params = Dictionary<String,String>()
         params["cursor"] = cursor
@@ -241,7 +241,7 @@ public class OffersService: @unchecked Sendable {
     /// - Returns: OfferResponseEnum with offer details on success or error on failure
     ///
     open func getOfferDetails(offerId: String) async -> OfferResponseEnum {
-        let result = await serviceHelper.GETRequestWithPath(path: "/offers/\(offerId)")
+        let result = await serviceHelper.GETRequestWithPath(path: "/offers/\(offerId.urlPathEncoded)")
         switch result {
         case .success(let data):
             do {
@@ -271,7 +271,7 @@ public class OffersService: @unchecked Sendable {
     /// - Returns: PageResponse containing trades for the offer or error
     ///
     open func getTrades(forOffer offerId: String, cursor: String? = nil, order: Order? = nil, limit: Int? = nil) async -> PageResponse<TradeResponse>.ResponseEnum {
-        var requestPath = "/offers/" + offerId + "/trades"
+        var requestPath = "/offers/" + offerId.urlPathEncoded + "/trades"
 
         var params = Dictionary<String,String>()
         params["cursor"] = cursor

--- a/stellarsdk/stellarsdk/service/OperationsService.swift
+++ b/stellarsdk/stellarsdk/service/OperationsService.swift
@@ -97,7 +97,7 @@ public class OperationsService: @unchecked Sendable {
     /// - Parameter join: Optional. Set to "transactions" to include transaction data in response
     /// - Returns: PageResponse containing operations for the account or error
     open func getOperations(forAccount accountId:String, from cursor:String? = nil, order:Order? = nil, limit:Int? = nil, includeFailed:Bool? = nil, join:String? = nil) async -> PageResponse<OperationResponse>.ResponseEnum {
-        let path = "/accounts/" + accountId + "/operations"
+        let path = "/accounts/" + accountId.urlPathEncoded + "/operations"
         return await getOperations(onPath: path, from:cursor, order:order, limit:limit, includeFailed:includeFailed, join:join)
     }
 
@@ -118,7 +118,7 @@ public class OperationsService: @unchecked Sendable {
             let cid = try? claimableBalanceId.decodeClaimableBalanceIdToHex() {
             id = cid
         }
-        let path = "/claimable_balances/" + id + "/operations"
+        let path = "/claimable_balances/" + id.urlPathEncoded + "/operations"
         return await getOperations(onPath: path, from:cursor, order:order, limit:limit, includeFailed:includeFailed, join:join)
     }
 
@@ -132,7 +132,7 @@ public class OperationsService: @unchecked Sendable {
     /// - Parameter join: Optional. Set to "transactions" to include transaction data in response
     /// - Returns: PageResponse containing operations for the ledger or error
     open func getOperations(forLedger ledger:String, from cursor:String? = nil, order:Order? = nil, limit:Int? = nil, includeFailed:Bool? = nil, join:String? = nil) async -> PageResponse<OperationResponse>.ResponseEnum {
-        let path = "/ledgers/" + ledger + "/operations"
+        let path = "/ledgers/" + ledger.urlPathEncoded + "/operations"
         return await getOperations(onPath: path, from:cursor, order:order, limit:limit, includeFailed:includeFailed, join:join)
     }
 
@@ -146,7 +146,7 @@ public class OperationsService: @unchecked Sendable {
     /// - Parameter join: Optional. Set to "transactions" to include transaction data in response
     /// - Returns: PageResponse containing operations for the transaction or error
     open func getOperations(forTransaction hash:String, from cursor:String? = nil, order:Order? = nil, limit:Int? = nil, includeFailed:Bool? = nil, join:String? = nil) async -> PageResponse<OperationResponse>.ResponseEnum {
-        let path = "/transactions/" + hash + "/operations"
+        let path = "/transactions/" + hash.urlPathEncoded + "/operations"
         return await getOperations(onPath: path, from:cursor, order:order, limit:limit, includeFailed:includeFailed, join:join)
     }
 
@@ -166,7 +166,7 @@ public class OperationsService: @unchecked Sendable {
         if liquidityPoolId.hasPrefix("L"), let idHex = try? liquidityPoolId.decodeLiquidityPoolIdToHex() {
             lidHex = idHex
         }
-        let path = "/liquidity_pools/" + lidHex + "/operations"
+        let path = "/liquidity_pools/" + lidHex.urlPathEncoded + "/operations"
         return await getOperations(onPath: path, from:cursor, order:order, limit:limit, includeFailed:includeFailed, join:join)
     }
 
@@ -179,7 +179,7 @@ public class OperationsService: @unchecked Sendable {
     /// - Parameter join: Optional. Set to "transactions" to include transaction data in response
     /// - Returns: OperationDetailsResponseEnum with operation details or error
     open func getOperationDetails(operationId:String, includeFailed:Bool? = nil, join:String? = nil) async -> OperationDetailsResponseEnum {
-        var requestPath = "/operations/" + operationId
+        var requestPath = "/operations/" + operationId.urlPathEncoded
         
         var params = Dictionary<String,String>()
         if let isIncludeFailed = includeFailed, isIncludeFailed { params["include_failed"] = "true" }
@@ -216,12 +216,12 @@ public class OperationsService: @unchecked Sendable {
         case .allOperations(let cursor):
             subpath = "/operations"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         case .operationsForAccount(let accountId, let cursor):
-            subpath = "/accounts/" + accountId + "/operations"
+            subpath = "/accounts/" + accountId.urlPathEncoded + "/operations"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         case .operationsForClaimableBalance(let claimableBalanceId, let cursor):
             var idHex = claimableBalanceId
@@ -229,28 +229,28 @@ public class OperationsService: @unchecked Sendable {
                 let cid = try? claimableBalanceId.decodeClaimableBalanceIdToHex() {
                 idHex = cid
             }
-            subpath = "/claimable_balances/" + idHex + "/operations"
+            subpath = "/claimable_balances/" + idHex.urlPathEncoded + "/operations"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         case .operationsForLedger(let ledger, let cursor):
-            subpath = "/ledgers/" + ledger + "/operations"
+            subpath = "/ledgers/" + ledger.urlPathEncoded + "/operations"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         case .operationsForTransaction(let transaction, let cursor):
-            subpath = "/transactions/" + transaction + "/operations"
+            subpath = "/transactions/" + transaction.urlPathEncoded + "/operations"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         case .operationsForLiquidityPool(let liquidityPool, let cursor):
             var lidHex = liquidityPool
             if liquidityPool.hasPrefix("L"), let idHex = try? liquidityPool.decodeLiquidityPoolIdToHex() {
                 lidHex = idHex
             }
-            subpath = "/liquidity_pools/" + lidHex + "/operations"
+            subpath = "/liquidity_pools/" + lidHex.urlPathEncoded + "/operations"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         }
         

--- a/stellarsdk/stellarsdk/service/PaymentsService.swift
+++ b/stellarsdk/stellarsdk/service/PaymentsService.swift
@@ -167,7 +167,7 @@ public class PaymentsService: @unchecked Sendable {
                 let operations = try self.operationsFactory.operationsFromResponseData(data: data)
                 return .success(page: operations)
             } catch {
-                return .failure(error: error as! HorizonRequestError)
+                return .failure(error: .parsingResponseFailed(message: error.localizedDescription))
             }
         case .failure(let error):
             return .failure(error:error)

--- a/stellarsdk/stellarsdk/service/PaymentsService.swift
+++ b/stellarsdk/stellarsdk/service/PaymentsService.swift
@@ -90,7 +90,7 @@ public class PaymentsService: @unchecked Sendable {
     ///
     /// See: [Stellar developer docs](https://developers.stellar.org)
     open func getPayments(forAccount accountId:String, from cursor:String? = nil, order:Order? = nil, limit:Int? = nil, includeFailed:Bool? = nil, join:String? = nil) async -> PageResponse<OperationResponse>.ResponseEnum {
-        let path = "/accounts/" + accountId + "/payments"
+        let path = "/accounts/" + accountId.urlPathEncoded + "/payments"
         return await getPayments(onPath: path, from:cursor, order:order, limit:limit, includeFailed:includeFailed, join:join)
     }
     
@@ -106,7 +106,7 @@ public class PaymentsService: @unchecked Sendable {
     ///
     /// See: [Stellar developer docs](https://developers.stellar.org)
     open func getPayments(forLedger ledger:String, from cursor:String? = nil, order:Order? = nil, limit:Int? = nil, includeFailed:Bool? = nil, join:String? = nil) async -> PageResponse<OperationResponse>.ResponseEnum {
-        let path = "/ledgers/" + ledger + "/payments"
+        let path = "/ledgers/" + ledger.urlPathEncoded + "/payments"
         return await getPayments(onPath: path, from:cursor, order:order, limit:limit, includeFailed:includeFailed, join:join)
     }
     
@@ -122,7 +122,7 @@ public class PaymentsService: @unchecked Sendable {
     ///
     /// See: [Stellar developer docs](https://developers.stellar.org)
     open func getPayments(forTransaction hash:String, from cursor:String? = nil, order:Order? = nil, limit:Int? = nil, includeFailed:Bool? = nil, join:String? = nil) async -> PageResponse<OperationResponse>.ResponseEnum {
-        let path = "/transactions/" + hash + "/payments"
+        let path = "/transactions/" + hash.urlPathEncoded + "/payments"
         return await getPayments(onPath: path, from:cursor, order:order, limit:limit, includeFailed:includeFailed, join:join)
     }
 
@@ -184,22 +184,22 @@ public class PaymentsService: @unchecked Sendable {
         case .allPayments(let cursor):
             subpath = "/payments"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         case .paymentsForAccount(let accountId, let cursor):
-            subpath = "/accounts/" + accountId + "/payments"
+            subpath = "/accounts/" + accountId.urlPathEncoded + "/payments"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         case .paymentsForLedger(let ledger, let cursor):
-            subpath = "/ledgers/" + ledger + "/payments"
+            subpath = "/ledgers/" + ledger.urlPathEncoded + "/payments"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         case .paymentsForTransaction(let transaction, let cursor):
-            subpath = "/transactions/" + transaction + "/payments"
+            subpath = "/transactions/" + transaction.urlPathEncoded + "/payments"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         }
     

--- a/stellarsdk/stellarsdk/service/TradesService.swift
+++ b/stellarsdk/stellarsdk/service/TradesService.swift
@@ -126,7 +126,7 @@ public class TradesService: @unchecked Sendable {
     /// - Parameter limit: Optional maximum number of records to return. Default: 10, max: 200
     /// - Returns: PageResponse containing trade records for the account or error
     open func getTrades(forAccount accountId:String, from cursor:String? = nil, order:Order? = nil, limit:Int? = nil) async -> PageResponse<TradeResponse>.ResponseEnum {
-        var requestPath = "/accounts/" + accountId + "/trades"
+        var requestPath = "/accounts/" + accountId.urlPathEncoded + "/trades"
         
         var params = Dictionary<String,String>()
         params["cursor"] = cursor
@@ -198,9 +198,9 @@ public class TradesService: @unchecked Sendable {
             }
             
         case .tradesForAccount(let accountId, let cursor):
-            subpath = "/accounts/" + accountId + "/trades"
+            subpath = "/accounts/" + accountId.urlPathEncoded + "/trades"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         }
     

--- a/stellarsdk/stellarsdk/service/TransactionsService.swift
+++ b/stellarsdk/stellarsdk/service/TransactionsService.swift
@@ -127,7 +127,7 @@ public class TransactionsService: @unchecked Sendable {
     /// - Returns: PageResponse containing transaction records or error
     open func getTransactions(forAccount accountId:String, from cursor:String? = nil, order:Order? = nil, limit:Int? = nil) async -> PageResponse<TransactionResponse>.ResponseEnum
     {
-        let path = "/accounts/" + accountId + "/transactions"
+        let path = "/accounts/" + accountId.urlPathEncoded + "/transactions"
         return await getTransactions(onPath: path, from:cursor, order:order, limit:limit)
     }
     
@@ -144,7 +144,7 @@ public class TransactionsService: @unchecked Sendable {
             let cid = try? claimableBalanceId.decodeClaimableBalanceIdToHex() {
             id = cid
         }
-        let path = "/claimable_balances/" + id + "/transactions"
+        let path = "/claimable_balances/" + id.urlPathEncoded + "/transactions"
         return await getTransactions(onPath: path, from:cursor, order:order, limit:limit)
     }
     
@@ -160,7 +160,7 @@ public class TransactionsService: @unchecked Sendable {
         if liquidityPoolId.hasPrefix("L"), let idHex = try? liquidityPoolId.decodeLiquidityPoolIdToHex() {
             lidHex = idHex
         }
-        let path = "/liquidity_pools/" + lidHex + "/transactions"
+        let path = "/liquidity_pools/" + lidHex.urlPathEncoded + "/transactions"
         return await getTransactions(onPath: path, from:cursor, order:order, limit:limit)
     }
     
@@ -172,7 +172,7 @@ public class TransactionsService: @unchecked Sendable {
     /// - Parameter limit: Optional maximum number of records to return (default 10, max 200)
     /// - Returns: PageResponse containing transaction records or error
     open func getTransactions(forLedger ledger:String, from cursor:String? = nil, order:Order? = nil, limit:Int? = nil) async -> PageResponse<TransactionResponse>.ResponseEnum {
-        let path = "/ledgers/" + ledger + "/transactions"
+        let path = "/ledgers/" + ledger.urlPathEncoded + "/transactions"
         return await getTransactions(onPath: path, from:cursor, order:order, limit:limit)
     }
     
@@ -181,7 +181,7 @@ public class TransactionsService: @unchecked Sendable {
     /// - Parameter transactionHash: The unique transaction hash identifier (hex-encoded)
     /// - Returns: TransactionDetailsResponseEnum with transaction details or error
     open func getTransactionDetails(transactionHash:String) async -> TransactionDetailsResponseEnum {
-        let requestPath = "/transactions/" + transactionHash
+        let requestPath = "/transactions/" + transactionHash.urlPathEncoded
 
         let result = await serviceHelper.GETRequestWithPath(path: requestPath)
         switch result {
@@ -347,7 +347,7 @@ public class TransactionsService: @unchecked Sendable {
 
         var remainingDestinations = destinations
         if let firstDestination = remainingDestinations.first {
-            let requestPath = "/accounts/\(firstDestination)"
+            let requestPath = "/accounts/\(firstDestination.urlPathEncoded)"
 
             let result = await serviceHelper.GETRequestWithPath(path: requestPath)
             switch result {
@@ -466,12 +466,12 @@ public class TransactionsService: @unchecked Sendable {
         case .allTransactions(let cursor):
             subpath = "/transactions"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         case .transactionsForAccount(let accountId, let cursor):
-            subpath = "/accounts/" + accountId + "/transactions"
+            subpath = "/accounts/" + accountId.urlPathEncoded + "/transactions"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         case .transactionsForClaimableBalance(let claimableBalanceId, let cursor):
             var idHex = claimableBalanceId
@@ -479,14 +479,14 @@ public class TransactionsService: @unchecked Sendable {
                 let cid = try? claimableBalanceId.decodeClaimableBalanceIdToHex() {
                 idHex = cid
             }
-            subpath = "/balances/" + idHex + "/transactions"
+            subpath = "/balances/" + idHex.urlPathEncoded + "/transactions"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         case .transactionsForLedger(let ledger, let cursor):
-            subpath = "/ledgers/" + ledger + "/transactions"
+            subpath = "/ledgers/" + ledger.urlPathEncoded + "/transactions"
             if let cursor = cursor {
-                subpath = subpath + "?cursor=" + cursor
+                subpath = subpath + "?cursor=" + cursor.urlQueryValueEncoded
             }
         }
 

--- a/stellarsdk/stellarsdk/soroban/SorobanServer.swift
+++ b/stellarsdk/stellarsdk/soroban/SorobanServer.swift
@@ -1056,7 +1056,9 @@ public class SorobanServer: @unchecked Sendable {
     /// Executes HTTP POST request to Soroban RPC endpoint with JSON-RPC 2.0 protocol.
     /// Handles request headers, response validation, and error mapping for all RPC operations.
     private func request(body: Data?) async -> RpcResult {
-        let url = URL(string: endpoint)!
+        guard let url = URL(string: endpoint) else {
+            return .failure(error: .requestFailed(message: "Invalid Soroban RPC endpoint URL: \(endpoint)"))
+        }
         var urlRequest = URLRequest(url: url)
 
         requestHeaders.forEach {

--- a/stellarsdk/stellarsdk/transfer_server_protocol/TransferServerService.swift
+++ b/stellarsdk/stellarsdk/transfer_server_protocol/TransferServerService.swift
@@ -179,49 +179,49 @@ public final class TransferServerService: @unchecked Sendable {
     /// - Parameter request: Deposit request containing asset code, destination account, and optional parameters
     /// - Returns: DepositResponseEnum with instructions for transferring external assets to the anchor, or an error
     public func deposit(request: DepositRequest) async -> DepositResponseEnum {
-        var requestPath = "/deposit?asset_code=\(request.assetCode)&account=\(request.account)"
+        var requestPath = "/deposit?asset_code=\(request.assetCode.urlQueryValueEncoded)&account=\(request.account.urlQueryValueEncoded)"
         if let memoType = request.memoType {
-            requestPath += "&memo_type=\(memoType)"
+            requestPath += "&memo_type=\(memoType.urlQueryValueEncoded)"
         }
         if let memo = request.memo {
-            requestPath += "&memo=\(memo)"
+            requestPath += "&memo=\(memo.urlQueryValueEncoded)"
         }
         if let emailAddress = request.emailAddress {
-            requestPath += "&email_address=\(emailAddress)"
+            requestPath += "&email_address=\(emailAddress.urlQueryValueEncoded)"
         }
         if let type = request.type {
-            requestPath += "&type=\(type)"
+            requestPath += "&type=\(type.urlQueryValueEncoded)"
         }
         if let walletName = request.walletName {
-            requestPath += "&wallet_name=\(walletName)"
+            requestPath += "&wallet_name=\(walletName.urlQueryValueEncoded)"
         }
         if let walletUrl = request.walletUrl {
-            requestPath += "&wallet_url=\(walletUrl)"
+            requestPath += "&wallet_url=\(walletUrl.urlQueryValueEncoded)"
         }
         if let lang = request.lang {
-            requestPath += "&lang=\(lang)"
+            requestPath += "&lang=\(lang.urlQueryValueEncoded)"
         }
         if let onChangeCallback = request.onChangeCallback {
-            requestPath += "&on_change_callback=\(onChangeCallback)"
+            requestPath += "&on_change_callback=\(onChangeCallback.urlQueryValueEncoded)"
         }
         if let amount = request.amount {
-            requestPath += "&amount=\(amount)"
+            requestPath += "&amount=\(amount.urlQueryValueEncoded)"
         }
         if let countryCode = request.countryCode {
-            requestPath += "&country_code=\(countryCode)"
+            requestPath += "&country_code=\(countryCode.urlQueryValueEncoded)"
         }
         if let claimableBalanceSupported = request.claimableBalanceSupported {
             requestPath += "&claimable_balance_supported=\(claimableBalanceSupported)"
         }
         if let customerId = request.customerId {
-            requestPath += "&customer_id=\(customerId)"
+            requestPath += "&customer_id=\(customerId.urlQueryValueEncoded)"
         }
         if let locationId = request.locationId {
-            requestPath += "&location_id=\(locationId)"
+            requestPath += "&location_id=\(locationId.urlQueryValueEncoded)"
         }
         if let extraFields = request.extraFields {
             extraFields.forEach {
-                requestPath += "&\($0.key)=\($0.value)"
+                requestPath += "&\($0.key.urlQueryValueEncoded)=\($0.value.urlQueryValueEncoded)"
             }
         }
         
@@ -245,49 +245,49 @@ public final class TransferServerService: @unchecked Sendable {
     /// - Parameter request: Exchange deposit request specifying source asset, destination asset, amount, and account
     /// - Returns: DepositResponseEnum with conversion details and instructions, or an error
     public func depositExchange(request: DepositExchangeRequest) async -> DepositResponseEnum {
-        var requestPath = "/deposit-exchange?destination_asset=\(request.destinationAsset)&source_asset=\(request.sourceAsset)&amount=\(request.amount)&account=\(request.account)"
+        var requestPath = "/deposit-exchange?destination_asset=\(request.destinationAsset.urlQueryValueEncoded)&source_asset=\(request.sourceAsset.urlQueryValueEncoded)&amount=\(request.amount.urlQueryValueEncoded)&account=\(request.account.urlQueryValueEncoded)"
         if let quoteId = request.quoteId {
-            requestPath += "&quote_id=\(quoteId)"
+            requestPath += "&quote_id=\(quoteId.urlQueryValueEncoded)"
         }
         if let memoType = request.memoType {
-            requestPath += "&memo_type=\(memoType)"
+            requestPath += "&memo_type=\(memoType.urlQueryValueEncoded)"
         }
         if let memo = request.memo {
-            requestPath += "&memo=\(memo)"
+            requestPath += "&memo=\(memo.urlQueryValueEncoded)"
         }
         if let emailAddress = request.emailAddress {
-            requestPath += "&email_address=\(emailAddress)"
+            requestPath += "&email_address=\(emailAddress.urlQueryValueEncoded)"
         }
         if let type = request.type {
-            requestPath += "&type=\(type)"
+            requestPath += "&type=\(type.urlQueryValueEncoded)"
         }
         if let walletName = request.walletName {
-            requestPath += "&wallet_name=\(walletName)"
+            requestPath += "&wallet_name=\(walletName.urlQueryValueEncoded)"
         }
         if let walletUrl = request.walletUrl {
-            requestPath += "&wallet_url=\(walletUrl)"
+            requestPath += "&wallet_url=\(walletUrl.urlQueryValueEncoded)"
         }
         if let lang = request.lang {
-            requestPath += "&lang=\(lang)"
+            requestPath += "&lang=\(lang.urlQueryValueEncoded)"
         }
         if let onChangeCallback = request.onChangeCallback {
-            requestPath += "&on_change_callback=\(onChangeCallback)"
+            requestPath += "&on_change_callback=\(onChangeCallback.urlQueryValueEncoded)"
         }
         if let countryCode = request.countryCode {
-            requestPath += "&country_code=\(countryCode)"
+            requestPath += "&country_code=\(countryCode.urlQueryValueEncoded)"
         }
         if let claimableBalanceSupported = request.claimableBalanceSupported {
             requestPath += "&claimable_balance_supported=\(claimableBalanceSupported)"
         }
         if let customerId = request.customerId {
-            requestPath += "&customer_id=\(customerId)"
+            requestPath += "&customer_id=\(customerId.urlQueryValueEncoded)"
         }
         if let locationId = request.locationId {
-            requestPath += "&location_id=\(locationId)"
+            requestPath += "&location_id=\(locationId.urlQueryValueEncoded)"
         }
         if let extraFields = request.extraFields {
             extraFields.forEach {
-                requestPath += "&\($0.key)=\($0.value)"
+                requestPath += "&\($0.key.urlQueryValueEncoded)=\($0.value.urlQueryValueEncoded)"
             }
         }
         
@@ -311,55 +311,55 @@ public final class TransferServerService: @unchecked Sendable {
     /// - Parameter request: Withdrawal request with asset code, withdrawal type, destination, and optional account details
     /// - Returns: WithdrawResponseEnum with instructions for receiving off-chain assets, or an error
     public func withdraw(request: WithdrawRequest) async -> WithdrawResponseEnum {
-        var requestPath = "/withdraw?type=\(request.type)&asset_code=\(request.assetCode)"
+        var requestPath = "/withdraw?type=\(request.type.urlQueryValueEncoded)&asset_code=\(request.assetCode.urlQueryValueEncoded)"
         if let dest = request.dest {
-            requestPath += "&dest=\(dest)"
+            requestPath += "&dest=\(dest.urlQueryValueEncoded)"
         }
         if let destExtra = request.destExtra {
-            requestPath += "&dest_extra=\(destExtra)"
+            requestPath += "&dest_extra=\(destExtra.urlQueryValueEncoded)"
         }
         if let account = request.account {
-            requestPath += "&account=\(account)"
+            requestPath += "&account=\(account.urlQueryValueEncoded)"
         }
         if let memo = request.memo {
-            requestPath += "&memo=\(memo)"
+            requestPath += "&memo=\(memo.urlQueryValueEncoded)"
         }
         if let memoType = request.memoType {
-            requestPath += "&memo_type=\(memoType)"
+            requestPath += "&memo_type=\(memoType.urlQueryValueEncoded)"
         }
         if let walletName = request.walletName {
-            requestPath += "&wallet_name=\(walletName)"
+            requestPath += "&wallet_name=\(walletName.urlQueryValueEncoded)"
         }
         if let walletUrl = request.walletUrl {
-            requestPath += "&wallet_url=\(walletUrl)"
+            requestPath += "&wallet_url=\(walletUrl.urlQueryValueEncoded)"
         }
         if let lang = request.lang {
-            requestPath += "&lang=\(lang)"
+            requestPath += "&lang=\(lang.urlQueryValueEncoded)"
         }
         if let onChangeCallback = request.onChangeCallback {
-            requestPath += "&on_change_callback=\(onChangeCallback)"
+            requestPath += "&on_change_callback=\(onChangeCallback.urlQueryValueEncoded)"
         }
         if let amount = request.amount {
-            requestPath += "&amount=\(amount)"
+            requestPath += "&amount=\(amount.urlQueryValueEncoded)"
         }
         if let countryCode = request.countryCode {
-            requestPath += "&country_code=\(countryCode)"
+            requestPath += "&country_code=\(countryCode.urlQueryValueEncoded)"
         }
         if let refundMemo = request.refundMemo {
-            requestPath += "&refund_memo=\(refundMemo)"
+            requestPath += "&refund_memo=\(refundMemo.urlQueryValueEncoded)"
         }
         if let refundMemoType = request.refundMemoType {
-            requestPath += "&refund_memo_type=\(refundMemoType)"
+            requestPath += "&refund_memo_type=\(refundMemoType.urlQueryValueEncoded)"
         }
         if let customerId = request.customerId {
-            requestPath += "&customer_id=\(customerId)"
+            requestPath += "&customer_id=\(customerId.urlQueryValueEncoded)"
         }
         if let locationId = request.locationId {
-            requestPath += "&location_id=\(locationId)"
+            requestPath += "&location_id=\(locationId.urlQueryValueEncoded)"
         }
         if let extraFields = request.extraFields {
             extraFields.forEach {
-                requestPath += "&\($0.key)=\($0.value)"
+                requestPath += "&\($0.key.urlQueryValueEncoded)=\($0.value.urlQueryValueEncoded)"
             }
         }
         
@@ -383,55 +383,55 @@ public final class TransferServerService: @unchecked Sendable {
     /// - Parameter request: Exchange withdrawal request specifying source asset, destination asset, amount, and withdrawal details
     /// - Returns: WithdrawResponseEnum with conversion details and instructions, or an error
     public func withdrawExchange(request: WithdrawExchangeRequest) async -> WithdrawResponseEnum {
-        var requestPath = "/withdraw-exchange?type=\(request.type)&source_asset=\(request.sourceAsset)&destination_asset=\(request.destinationAsset)&amount=\(request.amount)"
+        var requestPath = "/withdraw-exchange?type=\(request.type.urlQueryValueEncoded)&source_asset=\(request.sourceAsset.urlQueryValueEncoded)&destination_asset=\(request.destinationAsset.urlQueryValueEncoded)&amount=\(request.amount.urlQueryValueEncoded)"
         if let quoteId = request.quoteId {
-            requestPath += "&quote_id=\(quoteId)"
+            requestPath += "&quote_id=\(quoteId.urlQueryValueEncoded)"
         }
         if let dest = request.dest {
-            requestPath += "&dest=\(dest)"
+            requestPath += "&dest=\(dest.urlQueryValueEncoded)"
         }
         if let destExtra = request.destExtra {
-            requestPath += "&dest_extra=\(destExtra)"
+            requestPath += "&dest_extra=\(destExtra.urlQueryValueEncoded)"
         }
         if let account = request.account {
-            requestPath += "&account=\(account)"
+            requestPath += "&account=\(account.urlQueryValueEncoded)"
         }
         if let memo = request.memo {
-            requestPath += "&memo=\(memo)"
+            requestPath += "&memo=\(memo.urlQueryValueEncoded)"
         }
         if let memoType = request.memoType {
-            requestPath += "&memo_type=\(memoType)"
+            requestPath += "&memo_type=\(memoType.urlQueryValueEncoded)"
         }
         if let walletName = request.walletName {
-            requestPath += "&wallet_name=\(walletName)"
+            requestPath += "&wallet_name=\(walletName.urlQueryValueEncoded)"
         }
         if let walletUrl = request.walletUrl {
-            requestPath += "&wallet_url=\(walletUrl)"
+            requestPath += "&wallet_url=\(walletUrl.urlQueryValueEncoded)"
         }
         if let lang = request.lang {
-            requestPath += "&lang=\(lang)"
+            requestPath += "&lang=\(lang.urlQueryValueEncoded)"
         }
         if let onChangeCallback = request.onChangeCallback {
-            requestPath += "&on_change_callback=\(onChangeCallback)"
+            requestPath += "&on_change_callback=\(onChangeCallback.urlQueryValueEncoded)"
         }
         if let countryCode = request.countryCode {
-            requestPath += "&country_code=\(countryCode)"
+            requestPath += "&country_code=\(countryCode.urlQueryValueEncoded)"
         }
         if let refundMemo = request.refundMemo {
-            requestPath += "&refund_memo=\(refundMemo)"
+            requestPath += "&refund_memo=\(refundMemo.urlQueryValueEncoded)"
         }
         if let refundMemoType = request.refundMemoType {
-            requestPath += "&refund_memo_type=\(refundMemoType)"
+            requestPath += "&refund_memo_type=\(refundMemoType.urlQueryValueEncoded)"
         }
         if let customerId = request.customerId {
-            requestPath += "&customer_id=\(customerId)"
+            requestPath += "&customer_id=\(customerId.urlQueryValueEncoded)"
         }
         if let locationId = request.locationId {
-            requestPath += "&location_id=\(locationId)"
+            requestPath += "&location_id=\(locationId.urlQueryValueEncoded)"
         }
         if let extraFields = request.extraFields {
             extraFields.forEach {
-                requestPath += "&\($0.key)=\($0.value)"
+                requestPath += "&\($0.key.urlQueryValueEncoded)=\($0.value.urlQueryValueEncoded)"
             }
         }
         
@@ -458,7 +458,7 @@ public final class TransferServerService: @unchecked Sendable {
     public func info(language: String? = nil, jwtToken:String? = nil) async -> AnchorInfoResponseEnum {
         var requestPath = "/info"
         if let language = language {
-            requestPath += "?lang=\(language)"
+            requestPath += "?lang=\(language.urlQueryValueEncoded)"
         }
         
         let result = await serviceHelper.GETRequestWithPath(path: requestPath, jwtToken: jwtToken)
@@ -481,10 +481,10 @@ public final class TransferServerService: @unchecked Sendable {
     /// - Parameter request: Fee request containing operation type, asset code, and transaction amount
     /// - Returns: AnchorFeeResponseEnum with calculated fee details for the specified operation, or an error
     public func fee(request: FeeRequest) async -> AnchorFeeResponseEnum {
-        var requestPath = "/fee?operation=\(request.operation)&asset_code=\(request.assetCode)&amount=\(request.amount)"
-        
+        var requestPath = "/fee?operation=\(request.operation.urlQueryValueEncoded)&asset_code=\(request.assetCode.urlQueryValueEncoded)&amount=\(String(request.amount).urlQueryValueEncoded)"
+
         if let type = request.type {
-            requestPath += "&type=\(type)"
+            requestPath += "&type=\(type.urlQueryValueEncoded)"
         }
         
         let result = await serviceHelper.GETRequestWithPath(path: requestPath, jwtToken: request.jwt)
@@ -507,22 +507,22 @@ public final class TransferServerService: @unchecked Sendable {
     /// - Parameter request: Transaction query request with account, asset code, optional filters, and SEP-10 JWT token
     /// - Returns: AnchorTransactionsResponseEnum with list of deposit and withdrawal transactions, or an error
     public func getTransactions(request: AnchorTransactionsRequest) async -> AnchorTransactionsResponseEnum {
-        var requestPath = "/transactions?asset_code=\(request.assetCode)&account=\(request.account)"
+        var requestPath = "/transactions?asset_code=\(request.assetCode.urlQueryValueEncoded)&account=\(request.account.urlQueryValueEncoded)"
         if let noOlderThanDate = request.noOlderThan {
             let noOlderThan = DateFormatter.iso8601.string(from: noOlderThanDate)
-            requestPath += "&no_older_than=\(noOlderThan)"
+            requestPath += "&no_older_than=\(noOlderThan.urlQueryValueEncoded)"
         }
         if let limit = request.limit {
             requestPath += "&limit=\(limit)"
         }
         if let kind = request.kind {
-            requestPath += "&kind=\(kind)"
+            requestPath += "&kind=\(kind.urlQueryValueEncoded)"
         }
         if let pagingId = request.pagingId {
-            requestPath += "&paging_id=\(pagingId)"
+            requestPath += "&paging_id=\(pagingId.urlQueryValueEncoded)"
         }
         if let lang = request.lang {
-            requestPath += "&lang=\(lang)"
+            requestPath += "&lang=\(lang.urlQueryValueEncoded)"
         }
         
         let result = await serviceHelper.GETRequestWithPath(path: requestPath, jwtToken: request.jwt)
@@ -546,31 +546,31 @@ public final class TransferServerService: @unchecked Sendable {
     /// - Returns: AnchorTransactionResponseEnum with detailed transaction status and processing information, or an error
     public func getTransaction(request: AnchorTransactionRequest) async -> AnchorTransactionResponseEnum {
         var requestPath = "/transaction?"
-        
+
         var first = true
         if let id = request.id {
-            requestPath += "id=\(id)"
+            requestPath += "id=\(id.urlQueryValueEncoded)"
             first = false
         }
         if let stellarTransactionId = request.stellarTransactionId {
             if !first {
                 requestPath += "&"
             }
-            requestPath += "stellar_transaction_id=\(stellarTransactionId)"
+            requestPath += "stellar_transaction_id=\(stellarTransactionId.urlQueryValueEncoded)"
             first = false
         }
         if let externalTransactionId = request.externalTransactionId {
             if !first {
                 requestPath += "&"
             }
-            requestPath += "external_transaction_id=\(externalTransactionId)"
+            requestPath += "external_transaction_id=\(externalTransactionId.urlQueryValueEncoded)"
             first = false
         }
         if let lang = request.lang {
             if !first {
                 requestPath += "&"
             }
-            requestPath += "lang=\(lang)"
+            requestPath += "lang=\(lang.urlQueryValueEncoded)"
         }
         
         let result = await serviceHelper.GETRequestWithPath(path: requestPath, jwtToken: request.jwt)
@@ -596,7 +596,7 @@ public final class TransferServerService: @unchecked Sendable {
     /// - Parameter body: Encoded request data containing the required customer information updates
     /// - Returns: AnchorTransactionResponseEnum with updated transaction details, or an error
     public func patchTransaction(id:String, jwt:String?, contentType:String, body:Data) async -> AnchorTransactionResponseEnum {
-        let requestPath = "/transaction/\(id)"
+        let requestPath = "/transaction/\(id.urlPathEncoded)"
         
         let result = await serviceHelper.PATCHRequestWithPath(path: requestPath, jwtToken: jwt, contentType: contentType, body: body)
         switch result {

--- a/stellarsdk/stellarsdk/uri_scheme/URIScheme.swift
+++ b/stellarsdk/stellarsdk/uri_scheme/URIScheme.swift
@@ -292,6 +292,15 @@ public final class URIScheme: Sendable {
         if let transactionEncodedEnvelope = try? transactionXDR?.encodedEnvelope() {
             if var callback = callback, callback.hasPrefix("url:") {
                 callback = String(callback.dropFirst(4))
+                guard let callbackURL = URL(string: callback),
+                      let scheme = callbackURL.scheme?.lowercased(),
+                      let host = callbackURL.host?.lowercased() else {
+                    return .failure(error: HorizonRequestError.requestFailed(message: "Invalid callback URL", horizonErrorResponse: nil))
+                }
+                let isLocalhost = host == "localhost" || host == "127.0.0.1" || host == "::1"
+                if scheme != "https" && !(scheme == "http" && isLocalhost) {
+                    return .failure(error: HorizonRequestError.requestFailed(message: "Callback URL must use HTTPS (HTTP allowed only for localhost)", horizonErrorResponse: nil))
+                }
                 let serviceHelper = ServiceHelper(baseURL: callback)
                 var dataStr = ""
                 if let urlEncodedTransaction = transactionEncodedEnvelope.urlEncoded {

--- a/stellarsdk/stellarsdk/uri_scheme/URIScheme.swift
+++ b/stellarsdk/stellarsdk/uri_scheme/URIScheme.swift
@@ -272,7 +272,7 @@ public final class URIScheme: Sendable {
                 return .failure(error: HorizonRequestError.requestFailed(message: "Transaction was not confirmed!", horizonErrorResponse: nil))
             }
             var transaction = transactionXDR
-            try? transaction.sign(keyPair: keyPair, network: .testnet)
+            try? transaction.sign(keyPair: keyPair, network: network)
             let callback1 = self.getValue(forParam: .callback, fromURL: url)
             let response = await self.submitTransaction(transactionXDR: transaction, callback: callback1, keyPair: keyPair)
             return response

--- a/stellarsdk/stellarsdk/utils/xdrCodable/XDRCodableExtensions.swift
+++ b/stellarsdk/stellarsdk/utils/xdrCodable/XDRCodableExtensions.swift
@@ -27,35 +27,14 @@ func decodeArray<T: Codable>(type:T.Type, dec:Decoder, maxCount: UInt32 = UInt32
     guard count <= maxCount else {
         throw StellarSDKError.xdrDecodingError(message: "Array count \(count) exceeds maximum \(maxCount)")
     }
+    guard count <= decoder.remainingBytes else {
+        throw XDRDecoder.Error.prematureEndOfData
+    }
     var array = [T]()
-    array.reserveCapacity(Int(count))
+    array.reserveCapacity(min(Int(count), decoder.remainingBytes))
     for _ in 0 ..< count {
         let decoded = try decoder.decode(type)
         array.append(decoded)
-    }
-
-    return array
-}
-
-/// Decodes an array of optional XDR-encodable objects from a decoder.
-///
-/// Similar to decodeArray but handles optional elements.
-///
-/// - Parameter type: Type of elements to decode
-/// - Parameter dec: Decoder to read from
-/// - Returns: Decoded array of elements (skipping nil values)
-/// - Throws: XDRDecoder.Error if decoding fails
-func decodeArrayOpt<T: Codable>(type:T.Type, dec:Decoder) throws -> [T] {
-    guard let decoder = dec as? XDRDecoder else {
-        throw XDRDecoder.Error.typeNotConformingToDecodable(Decoder.Type.self)
-    }
-
-    let count = try decoder.decode(UInt32.self)
-    var array = [T]()
-    for _ in 0 ..< count {
-        if let decoded =  try decodeArray(type: type, dec: decoder).first {// try type.init(from: decoder)
-            array.append(decoded)
-        }
     }
 
     return array
@@ -80,8 +59,11 @@ func decodeArrayOfOptional<T: Codable>(type: T.Type, dec: Decoder, maxCount: UIn
     guard count <= maxCount else {
         throw StellarSDKError.xdrDecodingError(message: "Array count \(count) exceeds maximum \(maxCount)")
     }
+    guard count <= decoder.remainingBytes else {
+        throw XDRDecoder.Error.prematureEndOfData
+    }
     var array = [T?]()
-    array.reserveCapacity(Int(count))
+    array.reserveCapacity(min(Int(count), decoder.remainingBytes))
     for _ in 0..<count {
         let present = try decoder.decode(Int32.self)
         if present != 0 {
@@ -166,8 +148,11 @@ extension Array: XDRCodable where Element: XDRCodable {
     public init(fromBinary decoder: XDRDecoder) throws {
         let binaryElement = Element.self
         let count = try decoder.decode(UInt32.self)
+        guard count <= decoder.remainingBytes else {
+            throw XDRDecoder.Error.prematureEndOfData
+        }
         self.init()
-        self.reserveCapacity(Int(count))
+        self.reserveCapacity(Swift.min(Int(count), decoder.remainingBytes))
         for _ in 0 ..< count {
             let decoded = try decoder.decode(binaryElement)
             self.append(decoded)

--- a/stellarsdk/stellarsdk/utils/xdrCodable/XDRDecoder.swift
+++ b/stellarsdk/stellarsdk/utils/xdrCodable/XDRDecoder.swift
@@ -145,6 +145,14 @@ public extension XDRDecoder {
     }
 }
 
+/// Internal methods for reading decoder state.
+extension XDRDecoder {
+    /// The number of bytes remaining in the buffer from the current cursor position.
+    var remainingBytes: Int {
+        return max(data.count - cursor, 0)
+    }
+}
+
 /// Internal methods for decoding raw data.
 private extension XDRDecoder {
     /// Read the given number of bytes into the given pointer, advancing the cursor

--- a/stellarsdk/stellarsdk/web_authentication/WebAuthenticator.swift
+++ b/stellarsdk/stellarsdk/web_authentication/WebAuthenticator.swift
@@ -377,12 +377,12 @@ public final class WebAuthenticator: Sendable {
     /// - Returns: ChallengeResponseEnum with base64-encoded challenge transaction or error
     public func getChallenge(forAccount accountId:String, memo:UInt64? = nil, homeDomain:String? = nil, clientDomain:String? = nil) async -> ChallengeResponseEnum {
         
-        var path = (homeDomain != nil) ? "?account=\(accountId)&home_domain=\(homeDomain!)" : "?account=\(accountId)"
-        
+        var path = (homeDomain != nil) ? "?account=\(accountId.urlQueryValueEncoded)&home_domain=\(homeDomain!.urlQueryValueEncoded)" : "?account=\(accountId.urlQueryValueEncoded)"
+
         if let cd = clientDomain {
-            path.append("&client_domain=\(cd)");
+            path.append("&client_domain=\(cd.urlQueryValueEncoded)");
         }
-        
+
         if let mid = memo {
             if accountId.starts(with: "G") {
                 path.append("&memo=\(mid)");

--- a/stellarsdk/stellarsdk/web_authentication_contracts/WebAuthForContracts.swift
+++ b/stellarsdk/stellarsdk/web_authentication_contracts/WebAuthForContracts.swift
@@ -409,10 +409,10 @@ public final class WebAuthForContracts: @unchecked Sendable {
     ) async -> GetContractChallengeResponseEnum {
         let effectiveHomeDomain = homeDomain ?? serverHomeDomain
 
-        var path = "?account=\(clientAccountId)&home_domain=\(effectiveHomeDomain)"
+        var path = "?account=\(clientAccountId.urlQueryValueEncoded)&home_domain=\(effectiveHomeDomain.urlQueryValueEncoded)"
 
         if let cd = clientDomain {
-            path.append("&client_domain=\(cd)")
+            path.append("&client_domain=\(cd.urlQueryValueEncoded)")
         }
 
         let result = await serviceHelper.GETRequestWithPath(path: path)

--- a/stellarsdk/stellarsdkIntegrationTests/uri_scheme/URISchemeTestCase.swift
+++ b/stellarsdk/stellarsdkIntegrationTests/uri_scheme/URISchemeTestCase.swift
@@ -145,7 +145,7 @@ class URISchemeTestCase: XCTestCase {
     func signAndSubmitTransaction() async {
         let uriBuilder = URIScheme()
         let keyPair = try! KeyPair(secretSeed: secretSeed)
-        let responseEnum = await uriBuilder.signAndSubmitTransaction(forURL: self.validTestUrl!, signerKeyPair: keyPair)
+        let responseEnum = await uriBuilder.signAndSubmitTransaction(forURL: self.validTestUrl!, signerKeyPair: keyPair, network: .testnet)
         switch responseEnum {
         case .success:
             return
@@ -157,7 +157,7 @@ class URISchemeTestCase: XCTestCase {
             XCTFail()
         }
     }
-    
+
     func generateSignedCallbackTxTestUrl() {
         let keyPair = try! KeyPair(secretSeed: secretSeed)
         let result = uriValidator.signURI(url: self.unsignedTestUrl!, signerKeyPair: keyPair)
@@ -172,7 +172,7 @@ class URISchemeTestCase: XCTestCase {
     func signAndSubmitCallbackTxUrl() async {
         let uriBuilder = URIScheme()
         let keyPair = try! KeyPair(secretSeed: secretSeed)
-        let responseEnum = await uriBuilder.signAndSubmitTransaction(forURL: self.validCallbackTestUrl!, signerKeyPair: keyPair)
+        let responseEnum = await uriBuilder.signAndSubmitTransaction(forURL: self.validCallbackTestUrl!, signerKeyPair: keyPair, network: .testnet)
         switch responseEnum {
         case .success:
             return

--- a/stellarsdk/stellarsdkUnitTests/extensions/ExtensionsTestCase.swift
+++ b/stellarsdk/stellarsdkUnitTests/extensions/ExtensionsTestCase.swift
@@ -1666,6 +1666,131 @@ final class ExtensionsTestCase: XCTestCase {
             XCTAssertEqual(decoded, original, "Base32 round-trip should preserve data of length \(original.count)")
         }
     }
+
+    // MARK: - String+Encoding urlPathEncoded Tests
+
+    func testURLPathEncodedPathTraversal() {
+        // Path traversal sequences must be fully encoded so they cannot escape the intended path segment.
+        let traversal = "../../../etc/passwd"
+        let encoded = traversal.urlPathEncoded
+
+        // Forward slash must be percent-encoded to prevent directory traversal.
+        XCTAssertFalse(encoded.contains("/"), "Forward slash must be percent-encoded in a path segment")
+        XCTAssertTrue(encoded.contains("%2F"), "Forward slash must be encoded as %2F")
+
+        // Dots are safe URL path characters but the entire traversal sequence must not remain intact.
+        // Because slash is encoded, the ".." sequences are rendered harmless even if dots pass through.
+        XCTAssertFalse(encoded.contains("../"), "Path traversal sequence ../ must not appear in encoded output")
+
+        // The literal text of the original value must be preserved semantically via decoding.
+        XCTAssertEqual(encoded.removingPercentEncoding, traversal, "Round-trip must recover original string")
+    }
+
+    func testURLPathEncodedQueryInjectionChars() {
+        // Characters that could inject query parameters or alter URL structure must be encoded.
+        let injectionChars = "&=+;"
+        let encoded = injectionChars.urlPathEncoded
+
+        XCTAssertTrue(encoded.contains("%26"), "& must be encoded as %26")
+        XCTAssertTrue(encoded.contains("%3D"), "= must be encoded as %3D")
+        XCTAssertTrue(encoded.contains("%2B"), "+ must be encoded as %2B")
+        XCTAssertTrue(encoded.contains("%3B"), "; must be encoded as %3B")
+
+        // None of the raw injection characters should survive encoding.
+        XCTAssertFalse(encoded.contains("&"), "Raw & must not appear in path-encoded output")
+        XCTAssertFalse(encoded.contains("="), "Raw = must not appear in path-encoded output")
+        XCTAssertFalse(encoded.contains("+"), "Raw + must not appear in path-encoded output")
+        XCTAssertFalse(encoded.contains(";"), "Raw ; must not appear in path-encoded output")
+    }
+
+    func testURLPathEncodedAlphanumericPassthrough() {
+        // Unreserved characters must not be percent-encoded.
+        let safe = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+        let encoded = safe.urlPathEncoded
+        XCTAssertEqual(encoded, safe, "Unreserved characters must pass through urlPathEncoded unchanged")
+    }
+
+    func testURLPathEncodedEmptyString() {
+        let encoded = "".urlPathEncoded
+        XCTAssertEqual(encoded, "", "Empty string must encode to empty string")
+    }
+
+    // MARK: - String+Encoding urlQueryValueEncoded Tests
+
+    func testURLQueryValueEncodedParameterInjection() {
+        // A value containing & and = could inject additional query parameters; both must be encoded.
+        let injection = "value&extra_param=injected"
+        let encoded = injection.urlQueryValueEncoded
+
+        XCTAssertTrue(encoded.contains("%26"), "& must be encoded as %26 to prevent parameter injection")
+        XCTAssertTrue(encoded.contains("%3D"), "= must be encoded as %3D to prevent parameter injection")
+
+        XCTAssertFalse(encoded.contains("&"), "Raw & must not appear in query-value-encoded output")
+        XCTAssertFalse(encoded.contains("="), "Raw = must not appear in query-value-encoded output")
+
+        // The safe portion of the value must be preserved.
+        XCTAssertTrue(encoded.hasPrefix("value"), "The leading safe text must be preserved")
+        XCTAssertEqual(encoded.removingPercentEncoding, injection, "Round-trip must recover original string")
+    }
+
+    func testURLQueryValueEncodedPlusSign() {
+        // + must be percent-encoded because it is conventionally interpreted as a space in query strings.
+        let input = "value+with+plus"
+        let encoded = input.urlQueryValueEncoded
+
+        XCTAssertFalse(encoded.contains("+"), "Raw + must not appear in query-value-encoded output")
+        XCTAssertTrue(encoded.contains("%2B"), "+ must be encoded as %2B")
+        XCTAssertEqual(encoded.removingPercentEncoding, input, "Round-trip must recover original string")
+    }
+
+    func testURLQueryValueEncodedNormalString() {
+        // A plain alphanumeric value must pass through without modification.
+        let plain = "stellarAccountId123"
+        let encoded = plain.urlQueryValueEncoded
+        XCTAssertEqual(encoded, plain, "Plain alphanumeric string must pass through urlQueryValueEncoded unchanged")
+    }
+
+    // MARK: - Dictionary+HttpParams Injection Encoding Tests
+
+    func testDictionaryHttpParamsValueAmpersandEncoded() {
+        // A value containing & must be percent-encoded to prevent parameter injection.
+        let params: [String: String] = ["callback": "https://example.com/cb&admin=true"]
+        let query = params.stringFromHttpParameters()
+        XCTAssertNotNil(query, "stringFromHttpParameters must return a non-nil result")
+        XCTAssertFalse(query!.contains("&admin"), "Unencoded & in a value must not create a spurious parameter")
+        XCTAssertTrue(query!.contains("%26"), "& inside a value must be encoded as %26")
+    }
+
+    func testDictionaryHttpParamsValueEqualsEncoded() {
+        // A value containing = must be percent-encoded to prevent parameter injection.
+        let params: [String: String] = ["token": "abc=injected"]
+        let query = params.stringFromHttpParameters()
+        XCTAssertNotNil(query, "stringFromHttpParameters must return a non-nil result")
+        XCTAssertTrue(query!.contains("token="), "The key=value separator must be present")
+        XCTAssertTrue(query!.contains("%3D"), "= inside a value must be encoded as %3D")
+        // The encoded value must not introduce a second bare = after the key separator.
+        let components = query!.components(separatedBy: "=")
+        XCTAssertEqual(components.count, 2, "There must be exactly one bare = acting as key/value separator")
+    }
+
+    func testDictionaryHttpParamsKeyWithSpecialCharsEncoded() {
+        // A key containing special characters must also be percent-encoded.
+        let params: [String: String] = ["field&name": "value"]
+        let query = params.stringFromHttpParameters()
+        XCTAssertNotNil(query, "stringFromHttpParameters must return a non-nil result")
+        XCTAssertTrue(query!.contains("%26"), "& inside a key must be encoded as %26")
+        XCTAssertFalse(query!.contains("field&name="), "Unencoded & in a key must not appear in the query string")
+    }
+
+    func testDictionaryHttpParamsNormalPairUnchanged() {
+        // A simple alphanumeric key-value pair must produce a clean, unencoded query segment.
+        let params: [String: String] = ["cursor": "now", "limit": "20"]
+        let query = params.stringFromHttpParameters()
+        XCTAssertNotNil(query, "stringFromHttpParameters must return a non-nil result")
+        XCTAssertTrue(query!.contains("cursor=now"), "Plain key-value pair must appear unencoded")
+        XCTAssertTrue(query!.contains("limit=20"), "Plain key-value pair must appear unencoded")
+        XCTAssertTrue(query!.contains("&"), "Multiple parameters must be separated by &")
+    }
 }
 
 // MARK: - Test Helper Types for KeyedCoding+Collections

--- a/stellarsdk/stellarsdkUnitTests/operations/OperationXDRAmountUnitTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/operations/OperationXDRAmountUnitTests.swift
@@ -1,0 +1,152 @@
+//
+//  OperationXDRAmountUnitTests.swift
+//  stellarsdkTests
+//
+//  Created by Soneso on 28/03/26.
+//  Copyright © 2026 Soneso. All rights reserved.
+//
+
+import XCTest
+@testable import stellarsdk
+
+/// Unit tests for `Operation.toXDRAmount(amount:)` covering the security-hardened
+/// negative-amount guard and Int64 overflow guard introduced in the sec-improvements branch.
+class OperationXDRAmountUnitTests: XCTestCase {
+
+    // MARK: - Negative amount
+
+    func testNegativeAmountThrowsInvalidArgument() {
+        XCTAssertThrowsError(try Operation.toXDRAmount(amount: Decimal(-1))) { error in
+            guard let sdkError = error as? StellarSDKError else {
+                XCTFail("Expected StellarSDKError, got \(type(of: error))")
+                return
+            }
+            switch sdkError {
+            case .invalidArgument(let message):
+                XCTAssertTrue(
+                    message.contains("-1"),
+                    "Error message should contain the offending value; got: \(message)"
+                )
+            default:
+                XCTFail("Expected .invalidArgument, got \(sdkError)")
+            }
+        }
+    }
+
+    func testLargeNegativeAmountThrowsInvalidArgument() {
+        XCTAssertThrowsError(try Operation.toXDRAmount(amount: Decimal(-9999999))) { error in
+            guard let sdkError = error as? StellarSDKError else {
+                XCTFail("Expected StellarSDKError, got \(type(of: error))")
+                return
+            }
+            switch sdkError {
+            case .invalidArgument:
+                break
+            default:
+                XCTFail("Expected .invalidArgument, got \(sdkError)")
+            }
+        }
+    }
+
+    // MARK: - Overflow
+
+    /// An amount that, when multiplied by 10_000_000 (stroops/XLM), exceeds Int64.max.
+    /// Int64.max = 9_223_372_036_854_775_807 stroops.
+    /// 922_337_203_686 XLM * 10_000_000 = 9_223_372_036_860_000_000 > Int64.max.
+    func testOverflowAmountThrowsInvalidArgument() {
+        let overflowAmount = Decimal(922_337_203_686)
+        XCTAssertThrowsError(try Operation.toXDRAmount(amount: overflowAmount)) { error in
+            guard let sdkError = error as? StellarSDKError else {
+                XCTFail("Expected StellarSDKError, got \(type(of: error))")
+                return
+            }
+            switch sdkError {
+            case .invalidArgument(let message):
+                XCTAssertTrue(
+                    message.contains("large") || message.contains("Int64") || message.contains("range"),
+                    "Error message should indicate overflow; got: \(message)"
+                )
+            default:
+                XCTFail("Expected .invalidArgument, got \(sdkError)")
+            }
+        }
+    }
+
+    func testExtremelyLargeAmountThrowsInvalidArgument() {
+        let extremeAmount = Decimal(sign: .plus, exponent: 20, significand: 1)
+        XCTAssertThrowsError(try Operation.toXDRAmount(amount: extremeAmount)) { error in
+            guard let sdkError = error as? StellarSDKError else {
+                XCTFail("Expected StellarSDKError, got \(type(of: error))")
+                return
+            }
+            switch sdkError {
+            case .invalidArgument:
+                break
+            default:
+                XCTFail("Expected .invalidArgument, got \(sdkError)")
+            }
+        }
+    }
+
+    // MARK: - Zero
+
+    func testZeroAmountSucceeds() throws {
+        let result = try Operation.toXDRAmount(amount: Decimal(0))
+        XCTAssertEqual(result, 0, "Zero XLM should produce 0 stroops")
+    }
+
+    // MARK: - Valid amounts
+
+    func testTypicalAmountRoundTrip() throws {
+        // 100 XLM = 1_000_000_000 stroops
+        let result = try Operation.toXDRAmount(amount: Decimal(100))
+        XCTAssertEqual(result, 1_000_000_000)
+    }
+
+    func testFractionalAmountRoundTrip() throws {
+        // 0.5 XLM = 5_000_000 stroops
+        let result = try Operation.toXDRAmount(amount: Decimal(string: "0.5")!)
+        XCTAssertEqual(result, 5_000_000)
+    }
+
+    func testOneStroop() throws {
+        // 0.0000001 XLM = 1 stroop
+        let result = try Operation.toXDRAmount(amount: Decimal(string: "0.0000001")!)
+        XCTAssertEqual(result, 1)
+    }
+
+    /// Maximum valid amount: 922_337_203_685 XLM.
+    /// 922_337_203_685 * 10_000_000 = 9_223_372_036_850_000_000, which is <= Int64.max.
+    func testMaximumValidAmountSucceeds() throws {
+        let maxAmount = Decimal(922_337_203_685)
+        let result = try Operation.toXDRAmount(amount: maxAmount)
+        XCTAssertEqual(result, 9_223_372_036_850_000_000)
+    }
+
+    // MARK: - Fractional boundary near Int64.max
+
+    /// Int64.max = 9_223_372_036_854_775_807 stroops = 922337203685.4775807 XLM.
+    /// A fractional amount just at the maximum stroop value should succeed.
+    func testFractionalMaxStroopsSucceeds() throws {
+        let maxFractional = Decimal(string: "922337203685.4775807")!
+        let result = try Operation.toXDRAmount(amount: maxFractional)
+        XCTAssertEqual(result, Int64.max)
+    }
+
+    /// One stroop above Int64.max should throw.
+    func testFractionalOneStroopAboveMaxThrows() {
+        let aboveMax = Decimal(string: "922337203685.4775808")!
+        XCTAssertThrowsError(try Operation.toXDRAmount(amount: aboveMax)) { error in
+            guard let sdkError = error as? StellarSDKError else {
+                XCTFail("Expected StellarSDKError, got \(type(of: error))")
+                return
+            }
+            switch sdkError {
+            case .invalidArgument:
+                break
+            default:
+                XCTFail("Expected .invalidArgument, got \(sdkError)")
+            }
+        }
+    }
+}

--- a/stellarsdk/stellarsdkUnitTests/sep/uri_scheme/URISchemeUnitTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/sep/uri_scheme/URISchemeUnitTests.swift
@@ -1639,4 +1639,157 @@ class URISchemeUnitTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - Callback URL scheme validation tests
+
+    /// Helper to build a SEP-7 URI with an unencoded callback, simulating attacker-crafted input.
+    func buildURIWithRawCallback(_ callback: String) throws -> String {
+        let transactionXDR = try createTestTransactionXDR()
+        let envelope = try transactionXDR.encodedEnvelope()
+        let urlEncodedEnvelope = envelope.urlEncoded!
+        return "web+stellar:tx?xdr=\(urlEncodedEnvelope)&callback=\(callback)"
+    }
+
+    func testCallbackRejectsHTTP() async throws {
+        let uri = try buildURIWithRawCallback("url:http://attacker.com/steal")
+        let keyPair = try KeyPair(secretSeed: testSourceSecretSeed)
+        let result = await uriScheme.signAndSubmitTransaction(forURL: uri, signerKeyPair: keyPair, network: .testnet)
+        if case .failure(let error) = result {
+            if case .requestFailed(let message, _) = error {
+                XCTAssertTrue(message.contains("HTTPS"), "Expected HTTPS error, got: \(message)")
+            } else {
+                XCTFail("Expected requestFailed error, got: \(error)")
+            }
+        } else {
+            XCTFail("Expected failure for HTTP callback")
+        }
+    }
+
+    func testCallbackRejectsFileScheme() async throws {
+        let uri = try buildURIWithRawCallback("url:file:///etc/passwd")
+        let keyPair = try KeyPair(secretSeed: testSourceSecretSeed)
+        let result = await uriScheme.signAndSubmitTransaction(forURL: uri, signerKeyPair: keyPair, network: .testnet)
+        if case .failure(let error) = result {
+            if case .requestFailed(let message, _) = error {
+                XCTAssertTrue(message.contains("HTTPS") || message.contains("Invalid callback URL"),
+                              "Expected scheme validation error, got: \(message)")
+            } else {
+                XCTFail("Expected requestFailed error, got: \(error)")
+            }
+        } else {
+            XCTFail("Expected failure for file:// callback")
+        }
+    }
+
+    func testCallbackAllowsHTTPS() async throws {
+        let uri = try buildURIWithRawCallback("url:https://example.com/callback")
+        let keyPair = try KeyPair(secretSeed: testSourceSecretSeed)
+        let result = await uriScheme.signAndSubmitTransaction(forURL: uri, signerKeyPair: keyPair, network: .testnet)
+        // Must fail with a network error (not scheme validation), proving validation passed
+        if case .failure(let error) = result {
+            if case .requestFailed(let message, _) = error {
+                XCTAssertFalse(message.contains("HTTPS"), "HTTPS callback should not fail scheme validation")
+                XCTAssertFalse(message.contains("Invalid callback URL"), "HTTPS callback should not fail URL validation")
+            }
+        }
+    }
+
+    func testCallbackAllowsHTTPLocalhost() async throws {
+        let uri = try buildURIWithRawCallback("url:http://localhost:8080/callback")
+        let keyPair = try KeyPair(secretSeed: testSourceSecretSeed)
+        let result = await uriScheme.signAndSubmitTransaction(forURL: uri, signerKeyPair: keyPair, network: .testnet)
+        if case .failure(let error) = result {
+            if case .requestFailed(let message, _) = error {
+                XCTAssertFalse(message.contains("HTTPS"), "HTTP localhost should not fail scheme validation")
+                XCTAssertFalse(message.contains("Invalid callback URL"), "HTTP localhost should not fail URL validation")
+            }
+        }
+    }
+
+    func testCallbackAllowsHTTPLoopback() async throws {
+        let uri = try buildURIWithRawCallback("url:http://127.0.0.1:8080/callback")
+        let keyPair = try KeyPair(secretSeed: testSourceSecretSeed)
+        let result = await uriScheme.signAndSubmitTransaction(forURL: uri, signerKeyPair: keyPair, network: .testnet)
+        if case .failure(let error) = result {
+            if case .requestFailed(let message, _) = error {
+                XCTAssertFalse(message.contains("HTTPS"), "HTTP 127.0.0.1 should not fail scheme validation")
+                XCTAssertFalse(message.contains("Invalid callback URL"), "HTTP 127.0.0.1 should not fail URL validation")
+            }
+        }
+    }
+
+    func testCallbackRejectsUppercaseHTTP() async throws {
+        let uri = try buildURIWithRawCallback("url:HTTP://ATTACKER.COM/steal")
+        let keyPair = try KeyPair(secretSeed: testSourceSecretSeed)
+        let result = await uriScheme.signAndSubmitTransaction(forURL: uri, signerKeyPair: keyPair, network: .testnet)
+        if case .failure(let error) = result {
+            if case .requestFailed(let message, _) = error {
+                XCTAssertTrue(message.contains("HTTPS"), "Uppercase HTTP should be rejected, got: \(message)")
+            } else {
+                XCTFail("Expected requestFailed error, got: \(error)")
+            }
+        } else {
+            XCTFail("Expected failure for uppercase HTTP callback")
+        }
+    }
+
+    func testCallbackRejectsLocalhostSubdomain() async throws {
+        let uri = try buildURIWithRawCallback("url:http://localhost.attacker.com/steal")
+        let keyPair = try KeyPair(secretSeed: testSourceSecretSeed)
+        let result = await uriScheme.signAndSubmitTransaction(forURL: uri, signerKeyPair: keyPair, network: .testnet)
+        if case .failure(let error) = result {
+            if case .requestFailed(let message, _) = error {
+                XCTAssertTrue(message.contains("HTTPS"), "localhost.attacker.com should be rejected, got: \(message)")
+            } else {
+                XCTFail("Expected requestFailed error, got: \(error)")
+            }
+        } else {
+            XCTFail("Expected failure for localhost subdomain callback")
+        }
+    }
+
+    func testCallbackRejectsUserinfoBypass() async throws {
+        let uri = try buildURIWithRawCallback("url:http://localhost@attacker.com/steal")
+        let keyPair = try KeyPair(secretSeed: testSourceSecretSeed)
+        let result = await uriScheme.signAndSubmitTransaction(forURL: uri, signerKeyPair: keyPair, network: .testnet)
+        if case .failure(let error) = result {
+            if case .requestFailed(let message, _) = error {
+                XCTAssertTrue(message.contains("HTTPS"), "userinfo bypass should be rejected, got: \(message)")
+            } else {
+                XCTFail("Expected requestFailed error, got: \(error)")
+            }
+        } else {
+            XCTFail("Expected failure for userinfo bypass callback")
+        }
+    }
+
+    func testCallbackRejectsFTP() async throws {
+        let uri = try buildURIWithRawCallback("url:ftp://attacker.com/file")
+        let keyPair = try KeyPair(secretSeed: testSourceSecretSeed)
+        let result = await uriScheme.signAndSubmitTransaction(forURL: uri, signerKeyPair: keyPair, network: .testnet)
+        if case .failure(let error) = result {
+            if case .requestFailed(let message, _) = error {
+                XCTAssertTrue(message.contains("HTTPS"), "FTP should be rejected, got: \(message)")
+            } else {
+                XCTFail("Expected requestFailed error, got: \(error)")
+            }
+        } else {
+            XCTFail("Expected failure for FTP callback")
+        }
+    }
+
+    func testCallbackRejectsInvalidURL() async throws {
+        let uri = try buildURIWithRawCallback("url:")
+        let keyPair = try KeyPair(secretSeed: testSourceSecretSeed)
+        let result = await uriScheme.signAndSubmitTransaction(forURL: uri, signerKeyPair: keyPair, network: .testnet)
+        if case .failure(let error) = result {
+            if case .requestFailed(let message, _) = error {
+                XCTAssertTrue(message.contains("Invalid callback URL"), "Expected invalid URL error, got: \(message)")
+            } else {
+                XCTFail("Expected requestFailed error, got: \(error)")
+            }
+        } else {
+            XCTFail("Expected failure for invalid callback URL")
+        }
+    }
 }

--- a/stellarsdk/stellarsdkUnitTests/transactions/MemoTextUTF8UnitTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/transactions/MemoTextUTF8UnitTests.swift
@@ -1,0 +1,198 @@
+//
+//  MemoTextUTF8UnitTests.swift
+//  stellarsdkTests
+//
+//  Created by Soneso on 28/03/26.
+//  Copyright © 2026 Soneso. All rights reserved.
+//
+
+import XCTest
+import stellarsdk
+
+/// Unit tests that verify `Memo(text:)` enforces the 28-byte UTF-8 limit correctly.
+///
+/// The security fix changed the guard from `text.count` (Swift Character count) to
+/// `text.utf8.count` (byte count). These tests are designed so that they FAIL if
+/// someone reverts `text.utf8.count` back to `text.count`.
+///
+/// Test strategy uses CJK Unified Ideographs, each of which encodes as exactly
+/// 3 bytes in UTF-8 but counts as 1 Swift Character. This creates a clear divergence
+/// between `.count` and `.utf8.count` that exposes any regression.
+///
+/// Character "一" (U+4E00): .count contribution = 1, .utf8.count contribution = 3.
+class MemoTextUTF8UnitTests: XCTestCase {
+
+    // MARK: - Multi-byte characters: overflow path
+
+    /// 10 CJK characters: Swift .count == 10 (within 28), UTF-8 byte count == 30 (exceeds 28).
+    /// With the buggy `.count` guard this would NOT throw; with the correct `.utf8.count`
+    /// guard it MUST throw. This test fails if the guard is reverted to `.count`.
+    func testMultibyteStringExceedingByteLimitThrows() {
+        // 10 × U+4E00 = 10 Swift chars, 30 UTF-8 bytes
+        let text = String(repeating: "\u{4E00}", count: 10)
+        XCTAssertEqual(text.count, 10, "Precondition: 10 Swift Characters")
+        XCTAssertEqual(text.utf8.count, 30, "Precondition: 30 UTF-8 bytes")
+
+        XCTAssertThrowsError(try Memo(text: text)) { error in
+            guard let sdkError = error as? StellarSDKError else {
+                XCTFail("Expected StellarSDKError, got \(type(of: error))")
+                return
+            }
+            switch sdkError {
+            case .invalidArgument(let message):
+                XCTAssertTrue(
+                    message.contains("28"),
+                    "Error message should reference the 28-byte limit; got: \(message)"
+                )
+                XCTAssertTrue(
+                    message.contains("30"),
+                    "Error message should include the actual byte count (30); got: \(message)"
+                )
+            default:
+                XCTFail("Expected .invalidArgument, got \(sdkError)")
+            }
+        }
+    }
+
+    /// A shorter but still over-limit multi-byte string: 9 CJK chars + 2 ASCII = 29 bytes.
+    /// Swift .count == 11 (within 28), UTF-8 byte count == 29 (exceeds 28).
+    func testMixedStringJustAboveByteLimitThrows() {
+        // 9 × U+4E00 (27 bytes) + "ab" (2 bytes) = 29 bytes, 11 Swift chars
+        let text = String(repeating: "\u{4E00}", count: 9) + "ab"
+        XCTAssertEqual(text.count, 11, "Precondition: 11 Swift Characters")
+        XCTAssertEqual(text.utf8.count, 29, "Precondition: 29 UTF-8 bytes")
+
+        XCTAssertThrowsError(try Memo(text: text)) { error in
+            guard let sdkError = error as? StellarSDKError else {
+                XCTFail("Expected StellarSDKError, got \(type(of: error))")
+                return
+            }
+            switch sdkError {
+            case .invalidArgument:
+                break
+            default:
+                XCTFail("Expected .invalidArgument, got \(sdkError)")
+            }
+        }
+    }
+
+    // MARK: - Multi-byte characters: success path
+
+    /// Exactly 28 UTF-8 bytes using multi-byte characters.
+    /// 9 CJK chars (27 bytes) + 1 ASCII char (1 byte) = 28 bytes, 10 Swift chars.
+    /// This MUST succeed: byte count equals the limit exactly.
+    func testMultibyteStringAtExactByteLimitSucceeds() throws {
+        // 9 × U+4E00 (27 bytes) + "a" (1 byte) = 28 bytes, 10 Swift chars
+        let text = String(repeating: "\u{4E00}", count: 9) + "a"
+        XCTAssertEqual(text.count, 10, "Precondition: 10 Swift Characters")
+        XCTAssertEqual(text.utf8.count, 28, "Precondition: exactly 28 UTF-8 bytes")
+
+        let memo = try XCTUnwrap(try Memo(text: text))
+        switch memo {
+        case .text(let value):
+            XCTAssertEqual(value, text)
+        default:
+            XCTFail("Expected Memo.text")
+        }
+    }
+
+    /// 9 CJK characters: 27 UTF-8 bytes, 9 Swift chars — one byte under the limit.
+    func testMultibyteStringBelowByteLimitSucceeds() throws {
+        // 9 × U+4E00 = 27 bytes, 9 Swift chars
+        let text = String(repeating: "\u{4E00}", count: 9)
+        XCTAssertEqual(text.count, 9, "Precondition: 9 Swift Characters")
+        XCTAssertEqual(text.utf8.count, 27, "Precondition: 27 UTF-8 bytes")
+
+        let memo = try XCTUnwrap(try Memo(text: text))
+        switch memo {
+        case .text(let value):
+            XCTAssertEqual(value, text)
+        default:
+            XCTFail("Expected Memo.text")
+        }
+    }
+
+    // MARK: - Two-byte UTF-8 characters (U+0080–U+07FF)
+
+    /// Two-byte UTF-8 characters: U+00E9 ("é"). Each is 1 Swift char, 2 UTF-8 bytes.
+    /// 15 × "é" = 15 Swift chars, 30 UTF-8 bytes — must throw.
+    func testTwoByteCharactersExceedingLimitThrows() {
+        let text = String(repeating: "\u{00E9}", count: 15)
+        XCTAssertEqual(text.count, 15, "Precondition: 15 Swift Characters")
+        XCTAssertEqual(text.utf8.count, 30, "Precondition: 30 UTF-8 bytes")
+
+        XCTAssertThrowsError(try Memo(text: text)) { error in
+            guard let sdkError = error as? StellarSDKError else {
+                XCTFail("Expected StellarSDKError, got \(type(of: error))")
+                return
+            }
+            switch sdkError {
+            case .invalidArgument:
+                break
+            default:
+                XCTFail("Expected .invalidArgument, got \(sdkError)")
+            }
+        }
+    }
+
+    /// 14 × "é" = 14 Swift chars, 28 UTF-8 bytes — must succeed (exactly at limit).
+    func testTwoByteCharactersAtExactLimitSucceeds() throws {
+        let text = String(repeating: "\u{00E9}", count: 14)
+        XCTAssertEqual(text.count, 14, "Precondition: 14 Swift Characters")
+        XCTAssertEqual(text.utf8.count, 28, "Precondition: exactly 28 UTF-8 bytes")
+
+        let memo = try XCTUnwrap(try Memo(text: text))
+        switch memo {
+        case .text(let value):
+            XCTAssertEqual(value, text)
+        default:
+            XCTFail("Expected Memo.text")
+        }
+    }
+
+    // MARK: - ASCII: existing behaviour must be preserved
+
+    /// 28 ASCII characters = 28 Swift chars, 28 UTF-8 bytes: must succeed.
+    func testASCIIAtLimitSucceeds() throws {
+        let text = String(repeating: "x", count: 28)
+        XCTAssertEqual(text.count, 28)
+        XCTAssertEqual(text.utf8.count, 28)
+
+        let memo = try XCTUnwrap(try Memo(text: text))
+        switch memo {
+        case .text(let value):
+            XCTAssertEqual(value, text)
+        default:
+            XCTFail("Expected Memo.text")
+        }
+    }
+
+    /// 29 ASCII characters = 29 bytes: must throw.
+    func testASCIIAboveLimitThrows() {
+        let text = String(repeating: "x", count: 29)
+        XCTAssertThrowsError(try Memo(text: text)) { error in
+            guard let sdkError = error as? StellarSDKError else {
+                XCTFail("Expected StellarSDKError, got \(type(of: error))")
+                return
+            }
+            switch sdkError {
+            case .invalidArgument:
+                break
+            default:
+                XCTFail("Expected .invalidArgument, got \(sdkError)")
+            }
+        }
+    }
+
+    // MARK: - Empty string
+
+    func testEmptyStringSucceeds() throws {
+        let memo = try XCTUnwrap(try Memo(text: ""))
+        switch memo {
+        case .text(let value):
+            XCTAssertEqual(value, "")
+        default:
+            XCTFail("Expected Memo.text")
+        }
+    }
+}

--- a/stellarsdk/stellarsdkUnitTests/utils/XDREncoderDecoderDeepUnitTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/utils/XDREncoderDecoderDeepUnitTests.swift
@@ -960,6 +960,58 @@ class XDREncoderDecoderDeepUnitTests: XCTestCase {
         }
     }
 
+    func testDecodeArrayMaxCountDoesNotOOM() throws {
+        // Craft bytes with count = UInt32.max (0xFFFFFFFF) but only 4 bytes of payload.
+        // Without the reserveCapacity cap, this would attempt a multi-GB allocation.
+        var bytes: [UInt8] = []
+        // count = UInt32.max (big-endian)
+        bytes.append(contentsOf: [0xFF, 0xFF, 0xFF, 0xFF])
+        // Only 4 bytes of actual data
+        bytes.append(contentsOf: [0x00, 0x00, 0x00, 0x01])
+        let decoder = XDRDecoder(data: bytes)
+
+        XCTAssertThrowsError(try decodeArray(type: UInt32.self, dec: decoder)) { error in
+            guard case XDRDecoder.Error.prematureEndOfData = error else {
+                XCTFail("Expected prematureEndOfData, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testDecodeArrayFromBinaryMaxCountDoesNotOOM() throws {
+        // Same test but via Array.init(fromBinary:) which has its own reserveCapacity path.
+        var bytes: [UInt8] = []
+        // count = UInt32.max (big-endian)
+        bytes.append(contentsOf: [0xFF, 0xFF, 0xFF, 0xFF])
+        // Only 4 bytes of actual data
+        bytes.append(contentsOf: [0x00, 0x00, 0x00, 0x01])
+        let decoder = XDRDecoder(data: bytes)
+
+        XCTAssertThrowsError(try [UInt32](fromBinary: decoder)) { error in
+            guard case XDRDecoder.Error.prematureEndOfData = error else {
+                XCTFail("Expected prematureEndOfData, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testDecodeArrayOfOptionalMaxCountDoesNotOOM() throws {
+        // Same test but via decodeArrayOfOptional.
+        var bytes: [UInt8] = []
+        // count = UInt32.max (big-endian)
+        bytes.append(contentsOf: [0xFF, 0xFF, 0xFF, 0xFF])
+        // Only 4 bytes of actual data
+        bytes.append(contentsOf: [0x00, 0x00, 0x00, 0x01])
+        let decoder = XDRDecoder(data: bytes)
+
+        XCTAssertThrowsError(try decodeArrayOfOptional(type: UInt32.self, dec: decoder)) { error in
+            guard case XDRDecoder.Error.prematureEndOfData = error else {
+                XCTFail("Expected prematureEndOfData, got \(error)")
+                return
+            }
+        }
+    }
+
     // MARK: - WrappedData16 Tests
 
     func testWrappedData16RoundTrip() throws {

--- a/stellarsdk/stellarsdkUnitTests/utils/XDREncoderDecoderDeepUnitTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/utils/XDREncoderDecoderDeepUnitTests.swift
@@ -913,6 +913,44 @@ class XDREncoderDecoderDeepUnitTests: XCTestCase {
         }
     }
 
+    func testDecodeArrayMaxCountGuardFiresBeforeRemainingBytesGuard() throws {
+        // Build bytes for count=100 followed by 100 UInt32 elements (400 bytes of payload).
+        // remainingBytes after reading the count will be 400, which is >= count (100),
+        // so the remainingBytes guard would pass on its own.  Only the explicit maxCount
+        // cap should reject the decode.
+        let elementCount: UInt32 = 100
+        var bytes: [UInt8] = []
+
+        // Encode count as big-endian UInt32
+        bytes.append(UInt8((elementCount >> 24) & 0xFF))
+        bytes.append(UInt8((elementCount >> 16) & 0xFF))
+        bytes.append(UInt8((elementCount >>  8) & 0xFF))
+        bytes.append(UInt8( elementCount        & 0xFF))
+
+        // Append 100 valid UInt32 elements (each 4 bytes, big-endian), value = index
+        for i: UInt32 in 0..<elementCount {
+            bytes.append(UInt8((i >> 24) & 0xFF))
+            bytes.append(UInt8((i >> 16) & 0xFF))
+            bytes.append(UInt8((i >>  8) & 0xFF))
+            bytes.append(UInt8( i        & 0xFF))
+        }
+
+        // Confirm the payload is large enough that remainingBytes alone would not block decoding
+        // (400 bytes remaining >= count of 100).
+        XCTAssertEqual(bytes.count, 404) // 4 (count) + 400 (elements)
+
+        let decoder = XDRDecoder(data: bytes)
+
+        XCTAssertThrowsError(try decodeArray(type: UInt32.self, dec: decoder, maxCount: 50)) { error in
+            guard case StellarSDKError.xdrDecodingError(let message) = error else {
+                XCTFail("Expected StellarSDKError.xdrDecodingError, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("100"), "Error message should mention the actual count (100), got: \(message)")
+            XCTAssertTrue(message.contains("50"),  "Error message should mention the maximum (50), got: \(message)")
+        }
+    }
+
     func testDecodeArrayDefaultMaxCountAcceptsLargeArray() throws {
         // Encode an array of 100 elements
         let array: [UInt32] = Array(0..<100)


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions to commit SHAs, add least-privilege permission blocks, and configure Dependabot for automated updates
- Replace force-cast and force-unwrap crash paths with proper error handling in EffectsService, PaymentsService, and SorobanServer
- Validate memo text length by UTF-8 byte count instead of character count (Stellar protocol requires 28 bytes, not 28 characters)
- Detect and reject negative and overflowing amounts in `toXDRAmount` instead of silently returning 0
- Percent-encode all user-supplied values in URL path segments and query parameters across Horizon services, Federation, WebAuth, TransferServer, Interactive, KYC, and Quote
- Guard XDR array decoding against memory exhaustion from malicious element counts by validating against remaining buffer size before allocation
- Enforce HTTPS on SEP-7 callback URLs (HTTP allowed only for localhost/127.0.0.1/::1)
- Fix SEP-7 `signAndSubmitTransaction` ignoring the `network` parameter (was hardcoded to testnet)
- Update codecov-action to v6.0.0 and claude-code-action to v1.0.81
- Add regression tests for all security fixes (URL encoding, amount overflow, memo byte validation, XDR bounds, callback scheme enforcement)