### PR TITLE
fix(xdr): remove unused try on non-throwing TxRep format helpers

### DIFF
--- a/stellarsdk/stellarsdk/responses/xdr/AllowTrustOperationXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/AllowTrustOperationXDR.swift
@@ -35,7 +35,7 @@ public struct AllowTrustOperationXDR: XDRCodable, Sendable {
 
 extension AllowTrustOperationXDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
-    lines.append("\(prefix).trustor: \(try TxRepHelper.formatAccountId(self.trustor))")
+    lines.append("\(prefix).trustor: \(TxRepHelper.formatAccountId(self.trustor))")
     lines.append("\(prefix).asset: \(try TxRepHelper.formatAllowTrustAsset(self.asset))")
     lines.append("\(prefix).authorize: \(self.authorize)")
   }

--- a/stellarsdk/stellarsdk/responses/xdr/Alpha12XDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/Alpha12XDR.swift
@@ -28,7 +28,7 @@ public struct Alpha12XDR: XDRCodable, Sendable {
 extension Alpha12XDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
     lines.append("\(prefix).assetCode: \(TxRepHelper.bytesToHex(self.assetCode.wrapped))")
-    lines.append("\(prefix).issuer: \(try TxRepHelper.formatAccountId(self.issuer))")
+    lines.append("\(prefix).issuer: \(TxRepHelper.formatAccountId(self.issuer))")
   }
 
   public static func fromTxRep(_ map: [String: String], prefix: String) throws -> Alpha12XDR {

--- a/stellarsdk/stellarsdk/responses/xdr/Alpha4XDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/Alpha4XDR.swift
@@ -28,7 +28,7 @@ public struct Alpha4XDR: XDRCodable, Sendable {
 extension Alpha4XDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
     lines.append("\(prefix).assetCode: \(TxRepHelper.bytesToHex(self.assetCode.wrapped))")
-    lines.append("\(prefix).issuer: \(try TxRepHelper.formatAccountId(self.issuer))")
+    lines.append("\(prefix).issuer: \(TxRepHelper.formatAccountId(self.issuer))")
   }
 
   public static func fromTxRep(_ map: [String: String], prefix: String) throws -> Alpha4XDR {

--- a/stellarsdk/stellarsdk/responses/xdr/BeginSponsoringFutureReservesOpXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/BeginSponsoringFutureReservesOpXDR.swift
@@ -23,7 +23,7 @@ public struct BeginSponsoringFutureReservesOpXDR: XDRCodable, Sendable {
 
 extension BeginSponsoringFutureReservesOpXDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
-    lines.append("\(prefix).sponsoredID: \(try TxRepHelper.formatAccountId(self.sponsoredId))")
+    lines.append("\(prefix).sponsoredID: \(TxRepHelper.formatAccountId(self.sponsoredId))")
   }
 
   public static func fromTxRep(_ map: [String: String], prefix: String) throws -> BeginSponsoringFutureReservesOpXDR {

--- a/stellarsdk/stellarsdk/responses/xdr/ClaimantV0XDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/ClaimantV0XDR.swift
@@ -27,7 +27,7 @@ public struct ClaimantV0XDR: XDRCodable, Sendable {
 
 extension ClaimantV0XDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
-    lines.append("\(prefix).destination: \(try TxRepHelper.formatAccountId(self.accountID))")
+    lines.append("\(prefix).destination: \(TxRepHelper.formatAccountId(self.accountID))")
     try self.predicate.toTxRep(prefix: "\(prefix).predicate", lines: &lines)
   }
 

--- a/stellarsdk/stellarsdk/responses/xdr/ClawbackOpXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/ClawbackOpXDR.swift
@@ -35,7 +35,7 @@ public struct ClawbackOpXDR: XDRCodable, Sendable {
 
 extension ClawbackOpXDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
-    lines.append("\(prefix).asset: \(try TxRepHelper.formatAsset(self.asset))")
+    lines.append("\(prefix).asset: \(TxRepHelper.formatAsset(self.asset))")
     lines.append("\(prefix).from: \(try TxRepHelper.formatMuxedAccount(self.from))")
     lines.append("\(prefix).amount: \(self.amount)")
   }

--- a/stellarsdk/stellarsdk/responses/xdr/ContractIDPreimageXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/ContractIDPreimageXDR.swift
@@ -51,7 +51,7 @@ extension ContractIDPreimageXDR {
       try val.toTxRep(prefix: "\(prefix).fromAddress", lines: &lines)
     case .fromAsset(let val):
       lines.append("\(prefix).type: CONTRACT_ID_PREIMAGE_FROM_ASSET")
-      lines.append("\(prefix).fromAsset: \(try TxRepHelper.formatAsset(val))")
+      lines.append("\(prefix).fromAsset: \(TxRepHelper.formatAsset(val))")
     }
   }
 

--- a/stellarsdk/stellarsdk/responses/xdr/CreateAccountOperationXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/CreateAccountOperationXDR.swift
@@ -27,7 +27,7 @@ public struct CreateAccountOperationXDR: XDRCodable, Sendable {
 
 extension CreateAccountOperationXDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
-    lines.append("\(prefix).destination: \(try TxRepHelper.formatAccountId(self.destination))")
+    lines.append("\(prefix).destination: \(TxRepHelper.formatAccountId(self.destination))")
     lines.append("\(prefix).startingBalance: \(self.startingBalance)")
   }
 

--- a/stellarsdk/stellarsdk/responses/xdr/CreateClaimableBalanceOpXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/CreateClaimableBalanceOpXDR.swift
@@ -35,7 +35,7 @@ public struct CreateClaimableBalanceOpXDR: XDRCodable, Sendable {
 
 extension CreateClaimableBalanceOpXDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
-    lines.append("\(prefix).asset: \(try TxRepHelper.formatAsset(self.asset))")
+    lines.append("\(prefix).asset: \(TxRepHelper.formatAsset(self.asset))")
     lines.append("\(prefix).amount: \(self.amount)")
     lines.append("\(prefix).claimants.len: \(self.claimants.count)")
     for (i, item) in self.claimants.enumerated() {

--- a/stellarsdk/stellarsdk/responses/xdr/CreatePassiveOfferOperationXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/CreatePassiveOfferOperationXDR.swift
@@ -40,8 +40,8 @@ public struct CreatePassiveOfferOperationXDR: XDRCodable, Sendable {
 
 extension CreatePassiveOfferOperationXDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
-    lines.append("\(prefix).selling: \(try TxRepHelper.formatAsset(self.selling))")
-    lines.append("\(prefix).buying: \(try TxRepHelper.formatAsset(self.buying))")
+    lines.append("\(prefix).selling: \(TxRepHelper.formatAsset(self.selling))")
+    lines.append("\(prefix).buying: \(TxRepHelper.formatAsset(self.buying))")
     lines.append("\(prefix).amount: \(self.amount)")
     try self.price.toTxRep(prefix: "\(prefix).price", lines: &lines)
   }

--- a/stellarsdk/stellarsdk/responses/xdr/LedgerKeyAccountXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/LedgerKeyAccountXDR.swift
@@ -23,7 +23,7 @@ public struct LedgerKeyAccountXDR: XDRCodable, Sendable {
 
 extension LedgerKeyAccountXDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
-    lines.append("\(prefix).accountID: \(try TxRepHelper.formatAccountId(self.accountID))")
+    lines.append("\(prefix).accountID: \(TxRepHelper.formatAccountId(self.accountID))")
   }
 
   public static func fromTxRep(_ map: [String: String], prefix: String) throws -> LedgerKeyAccountXDR {

--- a/stellarsdk/stellarsdk/responses/xdr/LedgerKeyDataXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/LedgerKeyDataXDR.swift
@@ -27,7 +27,7 @@ public struct LedgerKeyDataXDR: XDRCodable, Sendable {
 
 extension LedgerKeyDataXDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
-    lines.append("\(prefix).accountID: \(try TxRepHelper.formatAccountId(self.accountID))")
+    lines.append("\(prefix).accountID: \(TxRepHelper.formatAccountId(self.accountID))")
     lines.append("\(prefix).dataName: \(TxRepHelper.escapeString(self.dataName))")
   }
 

--- a/stellarsdk/stellarsdk/responses/xdr/LedgerKeyOfferXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/LedgerKeyOfferXDR.swift
@@ -27,7 +27,7 @@ public struct LedgerKeyOfferXDR: XDRCodable, Sendable {
 
 extension LedgerKeyOfferXDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
-    lines.append("\(prefix).sellerID: \(try TxRepHelper.formatAccountId(self.sellerID))")
+    lines.append("\(prefix).sellerID: \(TxRepHelper.formatAccountId(self.sellerID))")
     lines.append("\(prefix).offerID: \(self.offerID)")
   }
 

--- a/stellarsdk/stellarsdk/responses/xdr/LedgerKeyTrustlineXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/LedgerKeyTrustlineXDR.swift
@@ -27,7 +27,7 @@ public struct LedgerKeyTrustLineXDR: XDRCodable, Sendable {
 
 extension LedgerKeyTrustLineXDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
-    lines.append("\(prefix).accountID: \(try TxRepHelper.formatAccountId(self.accountID))")
+    lines.append("\(prefix).accountID: \(TxRepHelper.formatAccountId(self.accountID))")
     try self.asset.toTxRep(prefix: "\(prefix).asset", lines: &lines)
   }
 

--- a/stellarsdk/stellarsdk/responses/xdr/LiquidityPoolConstantProductParametersXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/LiquidityPoolConstantProductParametersXDR.swift
@@ -35,8 +35,8 @@ public struct LiquidityPoolConstantProductParametersXDR: XDRCodable, Sendable {
 
 extension LiquidityPoolConstantProductParametersXDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
-    lines.append("\(prefix).assetA: \(try TxRepHelper.formatAsset(self.assetA))")
-    lines.append("\(prefix).assetB: \(try TxRepHelper.formatAsset(self.assetB))")
+    lines.append("\(prefix).assetA: \(TxRepHelper.formatAsset(self.assetA))")
+    lines.append("\(prefix).assetB: \(TxRepHelper.formatAsset(self.assetB))")
     lines.append("\(prefix).fee: \(self.fee)")
   }
 

--- a/stellarsdk/stellarsdk/responses/xdr/ManageOfferOperationXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/ManageOfferOperationXDR.swift
@@ -45,8 +45,8 @@ public struct ManageOfferOperationXDR: XDRCodable, Sendable {
 
 extension ManageOfferOperationXDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
-    lines.append("\(prefix).selling: \(try TxRepHelper.formatAsset(self.selling))")
-    lines.append("\(prefix).buying: \(try TxRepHelper.formatAsset(self.buying))")
+    lines.append("\(prefix).selling: \(TxRepHelper.formatAsset(self.selling))")
+    lines.append("\(prefix).buying: \(TxRepHelper.formatAsset(self.buying))")
     lines.append("\(prefix).amount: \(self.amount)")
     try self.price.toTxRep(prefix: "\(prefix).price", lines: &lines)
     lines.append("\(prefix).offerID: \(self.offerID)")

--- a/stellarsdk/stellarsdk/responses/xdr/OperationBodyXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/OperationBodyXDR.swift
@@ -227,14 +227,14 @@ extension OperationBodyXDR {
       try val.toTxRep(prefix: "\(prefix).paymentOp", lines: &lines)
     case .pathPaymentStrictReceiveOp(let val):
       lines.append("\(prefix).type: PATH_PAYMENT_STRICT_RECEIVE")
-      lines.append("\(prefix).pathPaymentStrictReceiveOp.sendAsset: \(try TxRepHelper.formatAsset(val.sendAsset))")
+      lines.append("\(prefix).pathPaymentStrictReceiveOp.sendAsset: \(TxRepHelper.formatAsset(val.sendAsset))")
       lines.append("\(prefix).pathPaymentStrictReceiveOp.sendMax: \(val.sendMax)")
       lines.append("\(prefix).pathPaymentStrictReceiveOp.destination: \(try TxRepHelper.formatMuxedAccount(val.destination))")
-      lines.append("\(prefix).pathPaymentStrictReceiveOp.destAsset: \(try TxRepHelper.formatAsset(val.destinationAsset))")
+      lines.append("\(prefix).pathPaymentStrictReceiveOp.destAsset: \(TxRepHelper.formatAsset(val.destinationAsset))")
       lines.append("\(prefix).pathPaymentStrictReceiveOp.destAmount: \(val.destinationAmount)")
       lines.append("\(prefix).pathPaymentStrictReceiveOp.path.len: \(val.path.count)")
       for (i, item) in val.path.enumerated() {
-        lines.append("\(prefix).pathPaymentStrictReceiveOp.path[\(i)]: \(try TxRepHelper.formatAsset(item))")
+        lines.append("\(prefix).pathPaymentStrictReceiveOp.path[\(i)]: \(TxRepHelper.formatAsset(item))")
       }
     case .manageSellOfferOp(let val):
       lines.append("\(prefix).type: MANAGE_SELL_OFFER")
@@ -264,21 +264,21 @@ extension OperationBodyXDR {
       try val.toTxRep(prefix: "\(prefix).bumpSequenceOp", lines: &lines)
     case .manageBuyOfferOp(let val):
       lines.append("\(prefix).type: MANAGE_BUY_OFFER")
-      lines.append("\(prefix).manageBuyOfferOp.selling: \(try TxRepHelper.formatAsset(val.selling))")
-      lines.append("\(prefix).manageBuyOfferOp.buying: \(try TxRepHelper.formatAsset(val.buying))")
+      lines.append("\(prefix).manageBuyOfferOp.selling: \(TxRepHelper.formatAsset(val.selling))")
+      lines.append("\(prefix).manageBuyOfferOp.buying: \(TxRepHelper.formatAsset(val.buying))")
       lines.append("\(prefix).manageBuyOfferOp.buyAmount: \(val.amount)")
       try val.price.toTxRep(prefix: "\(prefix).manageBuyOfferOp.price", lines: &lines)
       lines.append("\(prefix).manageBuyOfferOp.offerID: \(val.offerID)")
     case .pathPaymentStrictSendOp(let val):
       lines.append("\(prefix).type: PATH_PAYMENT_STRICT_SEND")
-      lines.append("\(prefix).pathPaymentStrictSendOp.sendAsset: \(try TxRepHelper.formatAsset(val.sendAsset))")
+      lines.append("\(prefix).pathPaymentStrictSendOp.sendAsset: \(TxRepHelper.formatAsset(val.sendAsset))")
       lines.append("\(prefix).pathPaymentStrictSendOp.sendAmount: \(val.sendMax)")
       lines.append("\(prefix).pathPaymentStrictSendOp.destination: \(try TxRepHelper.formatMuxedAccount(val.destination))")
-      lines.append("\(prefix).pathPaymentStrictSendOp.destAsset: \(try TxRepHelper.formatAsset(val.destinationAsset))")
+      lines.append("\(prefix).pathPaymentStrictSendOp.destAsset: \(TxRepHelper.formatAsset(val.destinationAsset))")
       lines.append("\(prefix).pathPaymentStrictSendOp.destMin: \(val.destinationAmount)")
       lines.append("\(prefix).pathPaymentStrictSendOp.path.len: \(val.path.count)")
       for (i, item) in val.path.enumerated() {
-        lines.append("\(prefix).pathPaymentStrictSendOp.path[\(i)]: \(try TxRepHelper.formatAsset(item))")
+        lines.append("\(prefix).pathPaymentStrictSendOp.path[\(i)]: \(TxRepHelper.formatAsset(item))")
       }
     case .createClaimableBalanceOp(let val):
       lines.append("\(prefix).type: CREATE_CLAIMABLE_BALANCE")
@@ -288,7 +288,7 @@ extension OperationBodyXDR {
       try val.toTxRep(prefix: "\(prefix).claimClaimableBalanceOp", lines: &lines)
     case .beginSponsoringFutureReservesOp(let val):
       lines.append("\(prefix).type: BEGIN_SPONSORING_FUTURE_RESERVES")
-      lines.append("\(prefix).beginSponsoringFutureReservesOp.sponsoredID: \(try TxRepHelper.formatAccountId(val.sponsoredId))")
+      lines.append("\(prefix).beginSponsoringFutureReservesOp.sponsoredID: \(TxRepHelper.formatAccountId(val.sponsoredId))")
     case .endSponsoringFutureReserves:
       lines.append("\(prefix).type: END_SPONSORING_FUTURE_RESERVES")
     case .revokeSponsorshipOp(let val):
@@ -302,8 +302,8 @@ extension OperationBodyXDR {
       try val.toTxRep(prefix: "\(prefix).clawbackClaimableBalanceOp", lines: &lines)
     case .setTrustLineFlagsOp(let val):
       lines.append("\(prefix).type: SET_TRUST_LINE_FLAGS")
-      lines.append("\(prefix).setTrustLineFlagsOp.trustor: \(try TxRepHelper.formatAccountId(val.accountID))")
-      lines.append("\(prefix).setTrustLineFlagsOp.asset: \(try TxRepHelper.formatAsset(val.asset))")
+      lines.append("\(prefix).setTrustLineFlagsOp.trustor: \(TxRepHelper.formatAccountId(val.accountID))")
+      lines.append("\(prefix).setTrustLineFlagsOp.asset: \(TxRepHelper.formatAsset(val.asset))")
       lines.append("\(prefix).setTrustLineFlagsOp.clearFlags: \(val.clearFlags)")
       lines.append("\(prefix).setTrustLineFlagsOp.setFlags: \(val.setFlags)")
     case .liquidityPoolDepositOp(let val):

--- a/stellarsdk/stellarsdk/responses/xdr/PathPaymentOperationXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/PathPaymentOperationXDR.swift
@@ -50,14 +50,14 @@ public struct PathPaymentOperationXDR: XDRCodable, Sendable {
 
 extension PathPaymentOperationXDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
-    lines.append("\(prefix).sendAsset: \(try TxRepHelper.formatAsset(self.sendAsset))")
+    lines.append("\(prefix).sendAsset: \(TxRepHelper.formatAsset(self.sendAsset))")
     lines.append("\(prefix).sendMax: \(self.sendMax)")
     lines.append("\(prefix).destination: \(try TxRepHelper.formatMuxedAccount(self.destination))")
-    lines.append("\(prefix).destAsset: \(try TxRepHelper.formatAsset(self.destinationAsset))")
+    lines.append("\(prefix).destAsset: \(TxRepHelper.formatAsset(self.destinationAsset))")
     lines.append("\(prefix).destAmount: \(self.destinationAmount)")
     lines.append("\(prefix).path.len: \(self.path.count)")
     for (i, item) in self.path.enumerated() {
-      lines.append("\(prefix).path[\(i)]: \(try TxRepHelper.formatAsset(item))")
+      lines.append("\(prefix).path[\(i)]: \(TxRepHelper.formatAsset(item))")
     }
   }
 

--- a/stellarsdk/stellarsdk/responses/xdr/PaymentOperationXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/PaymentOperationXDR.swift
@@ -36,7 +36,7 @@ public struct PaymentOperationXDR: XDRCodable, Sendable {
 extension PaymentOperationXDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
     lines.append("\(prefix).destination: \(try TxRepHelper.formatMuxedAccount(self.destination))")
-    lines.append("\(prefix).asset: \(try TxRepHelper.formatAsset(self.asset))")
+    lines.append("\(prefix).asset: \(TxRepHelper.formatAsset(self.asset))")
     lines.append("\(prefix).amount: \(self.amount)")
   }
 

--- a/stellarsdk/stellarsdk/responses/xdr/RevokeSponsorshipSignerXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/RevokeSponsorshipSignerXDR.swift
@@ -27,7 +27,7 @@ public struct RevokeSponsorshipSignerXDR: XDRCodable, Sendable {
 
 extension RevokeSponsorshipSignerXDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
-    lines.append("\(prefix).accountID: \(try TxRepHelper.formatAccountId(self.accountID))")
+    lines.append("\(prefix).accountID: \(TxRepHelper.formatAccountId(self.accountID))")
     lines.append("\(prefix).signerKey: \(try TxRepHelper.formatSignerKey(self.signerKey))")
   }
 

--- a/stellarsdk/stellarsdk/responses/xdr/SCAddressXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/SCAddressXDR.swift
@@ -69,7 +69,7 @@ extension SCAddressXDR {
     switch self {
     case .account(let val):
       lines.append("\(prefix).type: SC_ADDRESS_TYPE_ACCOUNT")
-      lines.append("\(prefix).accountId: \(try TxRepHelper.formatAccountId(val))")
+      lines.append("\(prefix).accountId: \(TxRepHelper.formatAccountId(val))")
     case .contract(let val):
       lines.append("\(prefix).type: SC_ADDRESS_TYPE_CONTRACT")
       lines.append("\(prefix).contractId: \(TxRepHelper.bytesToHex(val.wrapped))")

--- a/stellarsdk/stellarsdk/responses/xdr/SetOptionsOperationXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/SetOptionsOperationXDR.swift
@@ -157,7 +157,7 @@ extension SetOptionsOperationXDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
     if let val = self.inflationDestination {
       lines.append("\(prefix).inflationDest._present: true")
-      lines.append("\(prefix).inflationDest: \(try TxRepHelper.formatAccountId(val))")
+      lines.append("\(prefix).inflationDest: \(TxRepHelper.formatAccountId(val))")
     } else {
       lines.append("\(prefix).inflationDest._present: false")
     }

--- a/stellarsdk/stellarsdk/responses/xdr/SetTrustLineFlagsOpXDR.swift
+++ b/stellarsdk/stellarsdk/responses/xdr/SetTrustLineFlagsOpXDR.swift
@@ -40,8 +40,8 @@ public struct SetTrustLineFlagsOpXDR: XDRCodable, Sendable {
 
 extension SetTrustLineFlagsOpXDR {
   public func toTxRep(prefix: String, lines: inout [String]) throws {
-    lines.append("\(prefix).trustor: \(try TxRepHelper.formatAccountId(self.accountID))")
-    lines.append("\(prefix).asset: \(try TxRepHelper.formatAsset(self.asset))")
+    lines.append("\(prefix).trustor: \(TxRepHelper.formatAccountId(self.accountID))")
+    lines.append("\(prefix).asset: \(TxRepHelper.formatAsset(self.asset))")
     lines.append("\(prefix).clearFlags: \(self.clearFlags)")
     lines.append("\(prefix).setFlags: \(self.setFlags)")
   }

--- a/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZMultiSignerManagerTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZMultiSignerManagerTests.swift
@@ -1755,7 +1755,7 @@ final class OZMultiSignerManagerTests: XCTestCase {
 
         // Build a deterministic 32-byte auth digest (simulates the payload hash).
         let authDigest = Data(repeating: 0x42, count: 32)
-        let rawSig = Data(try keypair.sign([UInt8](authDigest)))
+        let rawSig = Data(keypair.sign([UInt8](authDigest)))
         XCTAssertEqual(rawSig.count, 64, "Ed25519 signature must be 64 bytes")
 
         let ed25519Sig = try OZEd25519Signature(publicKey: publicKey, signature: rawSig)

--- a/tools/xdr-generator/generator/generator.rb
+++ b/tools/xdr-generator/generator/generator.rb
@@ -694,6 +694,7 @@ class Generator < Xdrgen::Generators::Base
         name: base,
         format: TXREP_COMPACT_TYPES[base][:format],
         parse: TXREP_COMPACT_TYPES[base][:parse],
+        format_throws: TXREP_COMPACT_TYPES[base][:format_throws],
       }
     end
 
@@ -759,10 +760,12 @@ class Generator < Xdrgen::Generators::Base
         out.puts "lines.append(\"#{prefix_frag}: \\(TxRepHelper.bytesToHex(#{accessor}))\")"
       end
     when :compact
-      # Several format helpers (formatMuxedAccount, formatSignerKey, ...)
-      # throw on malformed input; mark all compact calls `try` uniformly so
-      # the struct toTxRep signature can be declared `throws`.
-      out.puts "lines.append(\"#{prefix_frag}: \\(try #{kind[:format]}(#{accessor}))\")"
+      # Prefix `try` only when the compact format helper can throw (per
+      # `format_throws` in TXREP_COMPACT_TYPES); a non-throwing helper would
+      # otherwise produce an unused-`try` warning.
+      call = "#{kind[:format]}(#{accessor})"
+      call = "try #{call}" if kind[:format_throws]
+      out.puts "lines.append(\"#{prefix_frag}: \\(#{call})\")"
     when :named
       out.puts "try #{accessor}.toTxRep(prefix: \"#{prefix_frag}\", lines: &lines)"
     when :array

--- a/tools/xdr-generator/generator/txrep_types.rb
+++ b/tools/xdr-generator/generator/txrep_types.rb
@@ -227,12 +227,14 @@ module TxRepTypes
   # ---------------------------------------------------------------------------
   #
   # Keyed by the RESOLVED Swift type name (after NAME_OVERRIDES / TYPE_OVERRIDES).
+  # `format_throws` is true when the format helper is declared `throws`; the
+  # generator emits `try` on the format call only for those entries.
   TXREP_COMPACT_TYPES = {
-    'PublicKey'            => { format: 'TxRepHelper.formatAccountId',       parse: 'TxRepHelper.parseAccountId'       },
-    'AllowTrustOpAssetXDR' => { format: 'TxRepHelper.formatAllowTrustAsset', parse: 'TxRepHelper.parseAllowTrustAsset' },
-    'AssetXDR'             => { format: 'TxRepHelper.formatAsset',           parse: 'TxRepHelper.parseAsset'           },
-    'MuxedAccountXDR'      => { format: 'TxRepHelper.formatMuxedAccount',    parse: 'TxRepHelper.parseMuxedAccount'    },
-    'SignerKeyXDR'         => { format: 'TxRepHelper.formatSignerKey',       parse: 'TxRepHelper.parseSignerKey'       },
+    'PublicKey'            => { format: 'TxRepHelper.formatAccountId',       parse: 'TxRepHelper.parseAccountId',       format_throws: false },
+    'AllowTrustOpAssetXDR' => { format: 'TxRepHelper.formatAllowTrustAsset', parse: 'TxRepHelper.parseAllowTrustAsset', format_throws: true  },
+    'AssetXDR'             => { format: 'TxRepHelper.formatAsset',           parse: 'TxRepHelper.parseAsset',           format_throws: false },
+    'MuxedAccountXDR'      => { format: 'TxRepHelper.formatMuxedAccount',    parse: 'TxRepHelper.parseMuxedAccount',    format_throws: true  },
+    'SignerKeyXDR'         => { format: 'TxRepHelper.formatSignerKey',       parse: 'TxRepHelper.parseSignerKey',       format_throws: true  },
   }.freeze
 
   # ---------------------------------------------------------------------------

--- a/tools/xdr-generator/test/generator_snapshot_test.rb
+++ b/tools/xdr-generator/test/generator_snapshot_test.rb
@@ -8,12 +8,26 @@ class GeneratorSnapshotTest < Minitest::Test
   XDR_DIR      = File.expand_path("../../../xdr", __dir__)
 
   def setup
-    @output_dir = Dir.mktmpdir("xdr_gen_test_")
-    generate_all
+    @output_dir = self.class.shared_output_dir
   end
 
-  def teardown
-    FileUtils.rm_rf(@output_dir)
+  # Generates the full XDR output once for the entire suite. minitest builds a
+  # fresh instance per test method, so per-instance memoization cannot help; the
+  # shared output directory is built lazily on first use and removed after the run.
+  def self.shared_output_dir
+    @shared_output_dir ||= begin
+      dir = Dir.mktmpdir("xdr_gen_test_")
+      Dir.chdir(File.expand_path("../../..", __dir__)) do
+        Xdrgen::Compilation.new(
+          Dir.glob("xdr/*.x"),
+          output_dir: dir + "/",
+          generator: Generator,
+          namespace: "stellar",
+        ).compile
+      end
+      Minitest.after_run { FileUtils.rm_rf(dir) }
+      dir
+    end
   end
 
   # -- Configuration tests --
@@ -130,18 +144,6 @@ class GeneratorSnapshotTest < Minitest::Test
   end
 
   private
-
-  def generate_all
-    return if @generated
-    Dir.chdir(File.expand_path("../../..", __dir__))
-    Xdrgen::Compilation.new(
-      Dir.glob("xdr/*.x"),
-      output_dir: @output_dir + "/",
-      generator: Generator,
-      namespace: "stellar",
-    ).compile
-    @generated = true
-  end
 
   def assert_snapshot(filename)
     generated = File.join(@output_dir, filename)

--- a/tools/xdr-generator/test/snapshots/OperationBodyXDR.swift
+++ b/tools/xdr-generator/test/snapshots/OperationBodyXDR.swift
@@ -227,14 +227,14 @@ extension OperationBodyXDR {
       try val.toTxRep(prefix: "\(prefix).paymentOp", lines: &lines)
     case .pathPaymentStrictReceiveOp(let val):
       lines.append("\(prefix).type: PATH_PAYMENT_STRICT_RECEIVE")
-      lines.append("\(prefix).pathPaymentStrictReceiveOp.sendAsset: \(try TxRepHelper.formatAsset(val.sendAsset))")
+      lines.append("\(prefix).pathPaymentStrictReceiveOp.sendAsset: \(TxRepHelper.formatAsset(val.sendAsset))")
       lines.append("\(prefix).pathPaymentStrictReceiveOp.sendMax: \(val.sendMax)")
       lines.append("\(prefix).pathPaymentStrictReceiveOp.destination: \(try TxRepHelper.formatMuxedAccount(val.destination))")
-      lines.append("\(prefix).pathPaymentStrictReceiveOp.destAsset: \(try TxRepHelper.formatAsset(val.destinationAsset))")
+      lines.append("\(prefix).pathPaymentStrictReceiveOp.destAsset: \(TxRepHelper.formatAsset(val.destinationAsset))")
       lines.append("\(prefix).pathPaymentStrictReceiveOp.destAmount: \(val.destinationAmount)")
       lines.append("\(prefix).pathPaymentStrictReceiveOp.path.len: \(val.path.count)")
       for (i, item) in val.path.enumerated() {
-        lines.append("\(prefix).pathPaymentStrictReceiveOp.path[\(i)]: \(try TxRepHelper.formatAsset(item))")
+        lines.append("\(prefix).pathPaymentStrictReceiveOp.path[\(i)]: \(TxRepHelper.formatAsset(item))")
       }
     case .manageSellOfferOp(let val):
       lines.append("\(prefix).type: MANAGE_SELL_OFFER")
@@ -264,21 +264,21 @@ extension OperationBodyXDR {
       try val.toTxRep(prefix: "\(prefix).bumpSequenceOp", lines: &lines)
     case .manageBuyOfferOp(let val):
       lines.append("\(prefix).type: MANAGE_BUY_OFFER")
-      lines.append("\(prefix).manageBuyOfferOp.selling: \(try TxRepHelper.formatAsset(val.selling))")
-      lines.append("\(prefix).manageBuyOfferOp.buying: \(try TxRepHelper.formatAsset(val.buying))")
+      lines.append("\(prefix).manageBuyOfferOp.selling: \(TxRepHelper.formatAsset(val.selling))")
+      lines.append("\(prefix).manageBuyOfferOp.buying: \(TxRepHelper.formatAsset(val.buying))")
       lines.append("\(prefix).manageBuyOfferOp.buyAmount: \(val.amount)")
       try val.price.toTxRep(prefix: "\(prefix).manageBuyOfferOp.price", lines: &lines)
       lines.append("\(prefix).manageBuyOfferOp.offerID: \(val.offerID)")
     case .pathPaymentStrictSendOp(let val):
       lines.append("\(prefix).type: PATH_PAYMENT_STRICT_SEND")
-      lines.append("\(prefix).pathPaymentStrictSendOp.sendAsset: \(try TxRepHelper.formatAsset(val.sendAsset))")
+      lines.append("\(prefix).pathPaymentStrictSendOp.sendAsset: \(TxRepHelper.formatAsset(val.sendAsset))")
       lines.append("\(prefix).pathPaymentStrictSendOp.sendAmount: \(val.sendMax)")
       lines.append("\(prefix).pathPaymentStrictSendOp.destination: \(try TxRepHelper.formatMuxedAccount(val.destination))")
-      lines.append("\(prefix).pathPaymentStrictSendOp.destAsset: \(try TxRepHelper.formatAsset(val.destinationAsset))")
+      lines.append("\(prefix).pathPaymentStrictSendOp.destAsset: \(TxRepHelper.formatAsset(val.destinationAsset))")
       lines.append("\(prefix).pathPaymentStrictSendOp.destMin: \(val.destinationAmount)")
       lines.append("\(prefix).pathPaymentStrictSendOp.path.len: \(val.path.count)")
       for (i, item) in val.path.enumerated() {
-        lines.append("\(prefix).pathPaymentStrictSendOp.path[\(i)]: \(try TxRepHelper.formatAsset(item))")
+        lines.append("\(prefix).pathPaymentStrictSendOp.path[\(i)]: \(TxRepHelper.formatAsset(item))")
       }
     case .createClaimableBalanceOp(let val):
       lines.append("\(prefix).type: CREATE_CLAIMABLE_BALANCE")
@@ -288,7 +288,7 @@ extension OperationBodyXDR {
       try val.toTxRep(prefix: "\(prefix).claimClaimableBalanceOp", lines: &lines)
     case .beginSponsoringFutureReservesOp(let val):
       lines.append("\(prefix).type: BEGIN_SPONSORING_FUTURE_RESERVES")
-      lines.append("\(prefix).beginSponsoringFutureReservesOp.sponsoredID: \(try TxRepHelper.formatAccountId(val.sponsoredId))")
+      lines.append("\(prefix).beginSponsoringFutureReservesOp.sponsoredID: \(TxRepHelper.formatAccountId(val.sponsoredId))")
     case .endSponsoringFutureReserves:
       lines.append("\(prefix).type: END_SPONSORING_FUTURE_RESERVES")
     case .revokeSponsorshipOp(let val):
@@ -302,8 +302,8 @@ extension OperationBodyXDR {
       try val.toTxRep(prefix: "\(prefix).clawbackClaimableBalanceOp", lines: &lines)
     case .setTrustLineFlagsOp(let val):
       lines.append("\(prefix).type: SET_TRUST_LINE_FLAGS")
-      lines.append("\(prefix).setTrustLineFlagsOp.trustor: \(try TxRepHelper.formatAccountId(val.accountID))")
-      lines.append("\(prefix).setTrustLineFlagsOp.asset: \(try TxRepHelper.formatAsset(val.asset))")
+      lines.append("\(prefix).setTrustLineFlagsOp.trustor: \(TxRepHelper.formatAccountId(val.accountID))")
+      lines.append("\(prefix).setTrustLineFlagsOp.asset: \(TxRepHelper.formatAsset(val.asset))")
       lines.append("\(prefix).setTrustLineFlagsOp.clearFlags: \(val.clearFlags)")
       lines.append("\(prefix).setTrustLineFlagsOp.setFlags: \(val.setFlags)")
     case .liquidityPoolDepositOp(let val):


### PR DESCRIPTION
## What
- XDR generator (`tools/xdr-generator`): generated `toTxRep` now emits `try` on a compact format helper only when that helper is declared `throws` (tracked via a `format_throws` flag on the compact-type registry). Non-throwing helpers (`formatAccountId`, `formatAsset`) no longer get a `try`.
- Regenerated the XDR Swift files accordingly (`XDR_COMMIT` unchanged — no protocol change) and updated the affected generator snapshot.
- Removed one spurious `try` on a non-throwing `KeyPair.sign(_:)` call in a unit test.
- Generator snapshot test now generates the output once for the whole suite instead of once per test method, reducing its runtime from minutes to ~60s.

## Why
The generated `toTxRep` code wrapped non-throwing format helpers in `try`, producing "no calls to throwing functions occur within 'try' expression" warnings on every build. This removes those warnings with no behavior change.

## Validation
- `swift build`: 0 warnings.
- `swift test --filter stellarsdkUnitTests`: 6913 passed, 3 skipped, 0 failures.
- Generator snapshot test: green; regeneration is deterministic (re-run produces no diff).