### PR TITLE
Fix SEP-6 fee description decoding and unknown transaction kind/status handling

### DIFF
--- a/stellarsdk/stellarsdk/transfer_server_protocol/responses/AnchorInfoResponse.swift
+++ b/stellarsdk/stellarsdk/transfer_server_protocol/responses/AnchorInfoResponse.swift
@@ -433,22 +433,28 @@ public struct AnchorFeeInfo: Decodable , Sendable {
     public let enabled: Bool
     /// Indicates whether authentication is required to access the fee endpoint.
     public let authenticationRequired:Bool?
-    
+    /// Optional. A description of how the fee is calculated, to be shown to the user. This is
+    /// especially relevant when the GET /fee endpoint is not supported and fees cannot be
+    /// modeled with fixed and percentage values per asset.
+    public let description:String?
+
     /// Properties to encode and decode
     private enum CodingKeys: String, CodingKey {
         case enabled
         case authenticationRequired = "authentication_required"
+        case description
     }
-    
+
     /**
      Initializer - creates a new instance by decoding from the given decoder.
-     
+
      - Parameter decoder: The decoder containing the data
      */
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         enabled = try values.decode(Bool.self, forKey: .enabled)
         authenticationRequired = try values.decodeIfPresent(Bool.self, forKey: .authenticationRequired)
+        description = try values.decodeIfPresent(String.self, forKey: .description)
     }
 }
 

--- a/stellarsdk/stellarsdk/transfer_server_protocol/responses/AnchorTransactionsResponse.swift
+++ b/stellarsdk/stellarsdk/transfer_server_protocol/responses/AnchorTransactionsResponse.swift
@@ -285,8 +285,18 @@ public struct AnchorTransaction: Decodable , Sendable {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         id = try values.decode(String.self, forKey: .id)
-        kind = AnchorTransactionKind(rawValue:try values.decode(String.self, forKey: .kind))!
-        status = AnchorTransactionStatus(rawValue: try values.decode(String.self, forKey: .status))!
+        let kindRawValue = try values.decode(String.self, forKey: .kind)
+        guard let decodedKind = AnchorTransactionKind(rawValue: kindRawValue) else {
+            throw DecodingError.dataCorruptedError(forKey: .kind, in: values,
+                debugDescription: "Unknown anchor transaction kind '\(kindRawValue)'")
+        }
+        kind = decodedKind
+        let statusRawValue = try values.decode(String.self, forKey: .status)
+        guard let decodedStatus = AnchorTransactionStatus(rawValue: statusRawValue) else {
+            throw DecodingError.dataCorruptedError(forKey: .status, in: values,
+                debugDescription: "Unknown anchor transaction status '\(statusRawValue)'")
+        }
+        status = decodedStatus
         statusEta = try values.decodeIfPresent(Int.self, forKey: .statusEta)
         moreInfoUrl = try values.decodeIfPresent(String.self, forKey: .moreInfoUrl)
         amountIn = try values.decodeIfPresent(String.self, forKey: .amountIn)

--- a/stellarsdk/stellarsdkUnitTests/sep/transfer_server_protocol/TransferServerProtocolUnitTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/sep/transfer_server_protocol/TransferServerProtocolUnitTests.swift
@@ -654,6 +654,50 @@ final class TransferServerProtocolUnitTests: XCTestCase {
         XCTAssertFalse(response.transaction!.authenticationRequired!)
     }
 
+    // MARK: - AnchorFeeInfo Tests
+
+    func testAnchorFeeInfoDecodingWithDescription() throws {
+        let description = "Fees vary from 3 to 7 percent based on the the assets transacted and method by which funds are delivered to or collected by the anchor."
+        let json = """
+        {
+            "fee": {
+                "enabled": false,
+                "authentication_required": true,
+                "description": "\(description)"
+            }
+        }
+        """
+
+        let data = json.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        let response = try decoder.decode(AnchorInfoResponse.self, from: data)
+
+        XCTAssertNotNil(response.fee)
+        XCTAssertFalse(response.fee!.enabled)
+        XCTAssertTrue(response.fee!.authenticationRequired!)
+        XCTAssertEqual(response.fee!.description, description)
+    }
+
+    func testAnchorFeeInfoDecodingWithoutDescription() throws {
+        let json = """
+        {
+            "fee": {
+                "enabled": true,
+                "authentication_required": false
+            }
+        }
+        """
+
+        let data = json.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        let response = try decoder.decode(AnchorInfoResponse.self, from: data)
+
+        XCTAssertNotNil(response.fee)
+        XCTAssertTrue(response.fee!.enabled)
+        XCTAssertFalse(response.fee!.authenticationRequired!)
+        XCTAssertNil(response.fee!.description)
+    }
+
     // MARK: - DepositAsset Tests
 
     func testDepositAssetDecodingWithEnabledTrue() throws {
@@ -1025,6 +1069,104 @@ final class TransferServerProtocolUnitTests: XCTestCase {
         let instruction = transaction.instructions?["organization.bank_number"]
         XCTAssertEqual(instruction?.value, "121122676")
         XCTAssertEqual(instruction?.description, "US bank routing number")
+    }
+
+    func testAnchorTransactionDecodingUnknownStatusThrows() throws {
+        let json = """
+        {
+            "id": "82fhs729f63dh0v4",
+            "kind": "deposit",
+            "status": "not_a_real_status",
+            "started_at": "2017-03-20T17:05:32.000Z"
+        }
+        """
+
+        let data = json.data(using: .utf8)!
+        let decoder = JSONDecoder()
+
+        XCTAssertThrowsError(try decoder.decode(AnchorTransaction.self, from: data)) { error in
+            guard case let DecodingError.dataCorrupted(context) = error else {
+                XCTFail("Expected DecodingError.dataCorrupted, got \(error)")
+                return
+            }
+            XCTAssertTrue(context.debugDescription.contains("not_a_real_status"),
+                          "Expected debug description to mention the unknown status value, got: \(context.debugDescription)")
+        }
+    }
+
+    func testAnchorTransactionDecodingUnknownKindThrows() throws {
+        let json = """
+        {
+            "id": "82fhs729f63dh0v4",
+            "kind": "not_a_real_kind",
+            "status": "completed",
+            "started_at": "2017-03-20T17:05:32.000Z"
+        }
+        """
+
+        let data = json.data(using: .utf8)!
+        let decoder = JSONDecoder()
+
+        XCTAssertThrowsError(try decoder.decode(AnchorTransaction.self, from: data)) { error in
+            guard case let DecodingError.dataCorrupted(context) = error else {
+                XCTFail("Expected DecodingError.dataCorrupted, got \(error)")
+                return
+            }
+            XCTAssertTrue(context.debugDescription.contains("not_a_real_kind"),
+                          "Expected debug description to mention the unknown kind value, got: \(context.debugDescription)")
+        }
+    }
+
+    func testAnchorTransactionDecodingValidKindAndStatusSucceeds() throws {
+        let json = """
+        {
+            "id": "82fhs729f63dh0v4",
+            "kind": "withdrawal-exchange",
+            "status": "pending_user_transfer_start",
+            "started_at": "2017-03-20T17:05:32.000Z"
+        }
+        """
+
+        let data = json.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        let transaction = try decoder.decode(AnchorTransaction.self, from: data)
+
+        XCTAssertEqual(transaction.id, "82fhs729f63dh0v4")
+        XCTAssertEqual(transaction.kind, .withdrawalExchange)
+        XCTAssertEqual(transaction.status, .pendingUserTransferStart)
+    }
+
+    func testAnchorTransactionsResponseDecodingUnknownStatusThrows() throws {
+        let json = """
+        {
+            "transactions": [
+                {
+                    "id": "82fhs729f63dh0v4",
+                    "kind": "deposit",
+                    "status": "pending_external",
+                    "started_at": "2017-03-20T17:05:32.000Z"
+                },
+                {
+                    "id": "72fhs729f63dh0v1",
+                    "kind": "deposit",
+                    "status": "totally_unknown_status",
+                    "started_at": "2017-03-20T17:00:02.000Z"
+                }
+            ]
+        }
+        """
+
+        let data = json.data(using: .utf8)!
+        let decoder = JSONDecoder()
+
+        XCTAssertThrowsError(try decoder.decode(AnchorTransactionsResponse.self, from: data)) { error in
+            guard case let DecodingError.dataCorrupted(context) = error else {
+                XCTFail("Expected DecodingError.dataCorrupted, got \(error)")
+                return
+            }
+            XCTAssertTrue(context.debugDescription.contains("totally_unknown_status"),
+                          "Expected debug description to mention the unknown status value, got: \(context.debugDescription)")
+        }
     }
 
     // MARK: - AnchorTransactionsResponse Tests

--- a/stellarsdk/stellarsdkUnitTests/sep/transfer_server_protocol/TransferServerServiceUnitTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/sep/transfer_server_protocol/TransferServerServiceUnitTests.swift
@@ -447,6 +447,7 @@ class TransferServerServiceUnitTests: XCTestCase {
             }
             
             XCTAssertFalse(info.fee!.enabled)
+            XCTAssertEqual("Fees vary from 3 to 7 percent based on the the assets transacted and method by which funds are delivered to or collected by the anchor.", info.fee!.description)
             XCTAssertTrue(info.transactions!.enabled)
             XCTAssertTrue(info.transactions!.authenticationRequired!)
             XCTAssertTrue(info.features!.accountCreation)


### PR DESCRIPTION
Fixes two SEP-6 response-handling issues found while building the stellar-swift-wallet-sdk test suite. Both changes are non-breaking.

## Fixes
- GET /info: `AnchorFeeInfo` now decodes the optional `description` field on the fee object. It was previously dropped, so consumers could never read the fee description.
- Anchor transactions: `AnchorTransaction` now decodes `kind` and `status` with a guarded failable initializer that throws a `DecodingError` on an unrecognized value, instead of force-unwrapping. Previously an unknown `kind`/`status` crashed the JSON decode. This affects both SEP-6 and SEP-24, which share `AnchorTransaction`.

## Tests
- Added unit tests in `TransferServerProtocolUnitTests` covering: the fee `description` present and absent, unknown `status`/`kind` now throwing (no crash), a valid kind/status still parsing, and the array-level decode failing on a bad transaction. Strengthened `TransferServerServiceUnitTests.testAnchorInfo` to assert the fee `description` end to end.
