### PR TITLE
Add headless connectToContract and RPC-visibility polling for OZ smart accounts

### DIFF
--- a/stellarsdk/stellarsdk/smartaccount/oz/OZConstants.swift
+++ b/stellarsdk/stellarsdk/smartaccount/oz/OZConstants.swift
@@ -74,14 +74,4 @@ public enum OZConstants {
     /// or error message; any larger payload is treated as a protocol failure
     /// and surfaces as `OZRelayerResponse(success: false, ...)`.
     public static let maxRelayerResponseBytes: Int = 256 * 1024
-
-    /// Credential id recorded for a headless (credential-less) connection.
-    ///
-    /// `ConnectedState.credentialId` is non-optional; the empty sentinel
-    /// preserves that invariant for a connection made through
-    /// ``OZWalletOperations/connectToContract(contractId:)``. The single-passkey
-    /// submit path refuses to run against this sentinel (see the headless guard
-    /// in ``OZTransactionOperations/submit(hostFunction:auth:forceMethod:resolveContextRuleIds:)``);
-    /// the multi-signer pipeline never reads it.
-    internal static let headlessCredentialIdSentinel = ""
 }

--- a/stellarsdk/stellarsdk/smartaccount/oz/OZConstants.swift
+++ b/stellarsdk/stellarsdk/smartaccount/oz/OZConstants.swift
@@ -23,6 +23,19 @@ public enum OZConstants {
     /// transferring Friendbot funds to a smart account wallet.
     public static let friendbotReserveXlm: Int = 5
 
+    /// Interval in milliseconds between Soroban RPC polls while waiting for a
+    /// Friendbot-funded temporary account to become visible to the RPC during
+    /// ``OZTransactionOperations/fundWallet(nativeTokenContract:forceMethod:)``.
+    public static let friendbotVisibilityPollIntervalMs: Int = 1500
+
+    /// Overall timeout in seconds for a Friendbot-funded temporary account to
+    /// become visible to the Soroban RPC during
+    /// ``OZTransactionOperations/fundWallet(nativeTokenContract:forceMethod:)``.
+    /// Friendbot confirms on Horizon within milliseconds, but the Soroban RPC
+    /// may lag by one or more ledger closes; polling absorbs that variable
+    /// propagation delay rather than assuming a single fixed wait.
+    public static let friendbotVisibilityTimeoutSeconds: Int = 45
+
     /// Default timeout for transaction submission and polling in seconds.
     public static let defaultTimeoutSeconds: Int = 30
 

--- a/stellarsdk/stellarsdk/smartaccount/oz/OZConstants.swift
+++ b/stellarsdk/stellarsdk/smartaccount/oz/OZConstants.swift
@@ -24,17 +24,22 @@ public enum OZConstants {
     public static let friendbotReserveXlm: Int = 5
 
     /// Interval in milliseconds between Soroban RPC polls while waiting for a
-    /// Friendbot-funded temporary account to become visible to the RPC during
-    /// ``OZTransactionOperations/fundWallet(nativeTokenContract:forceMethod:)``.
-    public static let friendbotVisibilityPollIntervalMs: Int = 1500
+    /// freshly created ledger entry to become visible to the RPC. Shared by the
+    /// funding-account visibility wait in
+    /// ``OZTransactionOperations/waitForAccountVisibleToRpc(accountId:pollIntervalMs:timeoutSeconds:)``
+    /// and the deployed-contract visibility wait in
+    /// ``OZTransactionOperations/waitForContractVisibleToRpc(contractId:pollIntervalMs:timeoutSeconds:)``.
+    public static let rpcVisibilityPollIntervalMs: Int = 1500
 
-    /// Overall timeout in seconds for a Friendbot-funded temporary account to
-    /// become visible to the Soroban RPC during
-    /// ``OZTransactionOperations/fundWallet(nativeTokenContract:forceMethod:)``.
-    /// Friendbot confirms on Horizon within milliseconds, but the Soroban RPC
-    /// may lag by one or more ledger closes; polling absorbs that variable
-    /// propagation delay rather than assuming a single fixed wait.
-    public static let friendbotVisibilityTimeoutSeconds: Int = 45
+    /// Overall timeout in seconds for a freshly created ledger entry to become
+    /// visible to the Soroban RPC. A funded account or a deployed contract
+    /// confirms on Horizon within milliseconds, but the Soroban RPC may lag by
+    /// one or more ledger closes; polling absorbs that variable propagation
+    /// delay rather than assuming a single fixed wait. Shared by
+    /// ``OZTransactionOperations/waitForAccountVisibleToRpc(accountId:pollIntervalMs:timeoutSeconds:)``
+    /// and
+    /// ``OZTransactionOperations/waitForContractVisibleToRpc(contractId:pollIntervalMs:timeoutSeconds:)``.
+    public static let rpcVisibilityTimeoutSeconds: Int = 45
 
     /// Default timeout for transaction submission and polling in seconds.
     public static let defaultTimeoutSeconds: Int = 30

--- a/stellarsdk/stellarsdk/smartaccount/oz/OZConstants.swift
+++ b/stellarsdk/stellarsdk/smartaccount/oz/OZConstants.swift
@@ -74,4 +74,14 @@ public enum OZConstants {
     /// or error message; any larger payload is treated as a protocol failure
     /// and surfaces as `OZRelayerResponse(success: false, ...)`.
     public static let maxRelayerResponseBytes: Int = 256 * 1024
+
+    /// Credential id recorded for a headless (credential-less) connection.
+    ///
+    /// `ConnectedState.credentialId` is non-optional; the empty sentinel
+    /// preserves that invariant for a connection made through
+    /// ``OZWalletOperations/connectToContract(contractId:)``. The single-passkey
+    /// submit path refuses to run against this sentinel (see the headless guard
+    /// in ``OZTransactionOperations/submit(hostFunction:auth:forceMethod:resolveContextRuleIds:)``);
+    /// the multi-signer pipeline never reads it.
+    internal static let headlessCredentialIdSentinel = ""
 }

--- a/stellarsdk/stellarsdk/smartaccount/oz/OZSmartAccountEvents.swift
+++ b/stellarsdk/stellarsdk/smartaccount/oz/OZSmartAccountEvents.swift
@@ -38,6 +38,17 @@ public enum OZSmartAccountEvent: Sendable, Equatable, Hashable {
     ///   - credentialId: The Base64URL-encoded credential ID.
     case walletConnected(contractId: String, credentialId: String)
 
+    /// Emitted when a credential-less headless connection is established via
+    /// ``OZWalletOperations/connectToContract(contractId:)``.
+    ///
+    /// A headless connection attaches the kit to an already-deployed smart
+    /// account by contract address alone, with no passkey credential. Unlike
+    /// ``walletConnected(contractId:credentialId:)`` it carries only the
+    /// contract id, so listeners never receive a meaningless empty credential.
+    ///
+    /// - Parameter contractId: The smart account contract address (`C…` strkey).
+    case walletConnectedHeadless(contractId: String)
+
     /// Emitted when a wallet is disconnected.
     ///
     /// This event is fired when `disconnect()` is called. The session is cleared,
@@ -122,6 +133,8 @@ public enum OZSmartAccountEvent: Sendable, Equatable, Hashable {
         switch self {
         case .walletConnected:
             return OZSmartAccountEventType.walletConnected.tag
+        case .walletConnectedHeadless:
+            return OZSmartAccountEventType.walletConnectedHeadless.tag
         case .walletDisconnected:
             return OZSmartAccountEventType.walletDisconnected.tag
         case .credentialCreated:
@@ -149,6 +162,8 @@ public enum OZSmartAccountEvent: Sendable, Equatable, Hashable {
         switch (lhs, rhs) {
         case let (.walletConnected(lc, li), .walletConnected(rc, ri)):
             return lc == rc && li == ri
+        case let (.walletConnectedHeadless(lc), .walletConnectedHeadless(rc)):
+            return lc == rc
         case let (.walletDisconnected(lc), .walletDisconnected(rc)):
             return lc == rc
         case let (.credentialCreated(lc), .credentialCreated(rc)):
@@ -180,6 +195,8 @@ public enum OZSmartAccountEvent: Sendable, Equatable, Hashable {
         case let .walletConnected(contractId, credentialId):
             hasher.combine(contractId)
             hasher.combine(credentialId)
+        case let .walletConnectedHeadless(contractId):
+            hasher.combine(contractId)
         case let .walletDisconnected(contractId):
             hasher.combine(contractId)
         case let .credentialCreated(credential):
@@ -225,6 +242,7 @@ public enum OZSmartAccountEvent: Sendable, Equatable, Hashable {
 /// ```
 public enum OZSmartAccountEventType: String, Sendable, CaseIterable {
     case walletConnected = "WalletConnected"
+    case walletConnectedHeadless = "WalletConnectedHeadless"
     case walletDisconnected = "WalletDisconnected"
     case credentialCreated = "CredentialCreated"
     case credentialDeleted = "CredentialDeleted"

--- a/stellarsdk/stellarsdk/smartaccount/oz/OZSmartAccountKit.swift
+++ b/stellarsdk/stellarsdk/smartaccount/oz/OZSmartAccountKit.swift
@@ -219,21 +219,38 @@ public final class OZSmartAccountKit: OZSmartAccountKitProtocol, @unchecked Send
 
     /// Indicates whether a wallet is currently connected.
     ///
-    /// A wallet is connected when both the credential id and the contract id
-    /// are set. This property reflects in-memory state only; after an app
-    /// restart consumers should call
-    /// ``OZWalletOperations/connectWallet(options:)`` to restore a saved session.
+    /// A connection is defined by the smart-account contract; the credential is
+    /// optional and is absent for a headless
+    /// ``OZWalletOperations/connectToContract(contractId:)`` connection. This
+    /// property reflects in-memory state only; after an app restart consumers
+    /// should call ``OZWalletOperations/connectWallet(options:)`` to restore a
+    /// saved session.
     public var isConnected: Bool {
         stateLock.lock()
         defer { stateLock.unlock() }
-        return _credentialId != nil && _contractId != nil
+        return _contractId != nil
     }
 
-    /// The credential identifier of the currently connected wallet, when a
-    /// wallet is connected.
+    /// Indicates whether the current connection is headless — bound to a
+    /// smart-account contract with no passkey credential.
     ///
-    /// Returns `nil` when no wallet is connected. The credential id is
-    /// Base64URL-encoded without padding, matching the WebAuthn
+    /// `true` only for a connection established through
+    /// ``OZWalletOperations/connectToContract(contractId:)``. Headless
+    /// connections are operable only through the multi-signer / external-signer
+    /// pipeline; the single-passkey paths reject them.
+    public var isHeadless: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return _contractId != nil && _credentialId == nil
+    }
+
+    /// The credential identifier of the currently connected wallet, when one is
+    /// present.
+    ///
+    /// Returns `nil` when no wallet is connected, and also for a headless
+    /// ``OZWalletOperations/connectToContract(contractId:)`` connection, which
+    /// binds a contract without a passkey credential. When present, the
+    /// credential id is Base64URL-encoded without padding, matching the WebAuthn
     /// specification.
     public var credentialId: String? {
         stateLock.lock()
@@ -320,12 +337,14 @@ public final class OZSmartAccountKit: OZSmartAccountKitProtocol, @unchecked Send
     ///
     /// Called by wallet-operations modules after a successful wallet
     /// creation or connection. Records the credential id and contract id
-    /// under the state lock.
+    /// under the state lock. A `nil` credential id marks a headless connection
+    /// bound to the contract alone.
     ///
     /// - Parameters:
-    ///   - credentialId: Base64URL-encoded credential identifier.
+    ///   - credentialId: Base64URL-encoded credential identifier, or `nil` for a
+    ///     headless connection.
     ///   - contractId: Smart account contract address (C-strkey).
-    internal func setConnectedState(credentialId: String, contractId: String) {
+    internal func setConnectedState(credentialId: String?, contractId: String) {
         stateLock.lock()
         _credentialId = credentialId
         _contractId = contractId
@@ -341,12 +360,12 @@ public final class OZSmartAccountKit: OZSmartAccountKitProtocol, @unchecked Send
     internal func requireConnected() throws -> ConnectedState {
         stateLock.lock()
         defer { stateLock.unlock() }
-        guard let cId = _credentialId, let ctId = _contractId else {
+        guard let ctId = _contractId else {
             throw SmartAccountWalletException.notConnected(
                 details: "No wallet connected. Call createWallet() or connectWallet() first."
             )
         }
-        return ConnectedState(credentialId: cId, contractId: ctId)
+        return ConnectedState(credentialId: _credentialId, contractId: ctId)
     }
 
     /// Disconnects the currently connected wallet.

--- a/stellarsdk/stellarsdk/smartaccount/oz/OZSmartAccountKitProtocol.swift
+++ b/stellarsdk/stellarsdk/smartaccount/oz/OZSmartAccountKitProtocol.swift
@@ -12,28 +12,29 @@ import Foundation
 /// The connected state of an OpenZeppelin Smart Account Kit.
 ///
 /// Returned by ``OZSmartAccountKitProtocol/requireConnected()`` after a successful
-/// wallet connection. Identifies the credential and contract address bound to the
-/// active session.
+/// wallet connection. Identifies the contract address bound to the active session
+/// and the passkey credential, when one is present.
 internal struct ConnectedState: Sendable, Equatable, Hashable {
 
-    /// WebAuthn credential ID (Base64URL-encoded, no padding).
-    let credentialId: String
+    /// WebAuthn credential ID (Base64URL-encoded, no padding), or `nil` for a
+    /// headless ``OZWalletOperations/connectToContract(contractId:)`` connection
+    /// bound to the contract without a passkey credential.
+    let credentialId: String?
 
     /// Smart account contract address (`C…` strkey).
     let contractId: String
 
     /// Initializes a new `ConnectedState`.
-    init(credentialId: String, contractId: String) {
+    init(credentialId: String?, contractId: String) {
         self.credentialId = credentialId
         self.contractId = contractId
     }
 
-    /// `true` when this state was produced by a headless
-    /// ``OZWalletOperations/connectToContract(contractId:)`` connection, which
-    /// records ``OZConstants/headlessCredentialIdSentinel`` in place of a real
-    /// passkey credential. The single-passkey submit path consults this to
+    /// `true` when this state carries no passkey credential — a headless
+    /// ``OZWalletOperations/connectToContract(contractId:)`` connection bound to
+    /// the contract alone. The single-passkey submit path consults this to
     /// reject headless callers up front.
-    var isHeadless: Bool { credentialId == OZConstants.headlessCredentialIdSentinel }
+    var isHeadless: Bool { credentialId == nil }
 }
 
 // MARK: - Credential Manager Protocol
@@ -225,17 +226,19 @@ internal protocol OZSmartAccountKitProtocol: AnyObject, Sendable {
 
     /// Returns the connected wallet identity.
     ///
-    /// - Returns: ``ConnectedState`` carrying the active credential and contract
-    ///   identifiers.
+    /// - Returns: ``ConnectedState`` carrying the contract identifier and the
+    ///   active credential when one is present (`nil` credential for a headless
+    ///   connection).
     /// - Throws: ``SmartAccountWalletException/NotConnected`` when no wallet is connected.
     func requireConnected() throws -> ConnectedState
 
     /// Records the connected state on the kit.
     ///
     /// - Parameters:
-    ///   - credentialId: Base64URL-encoded credential identifier.
+    ///   - credentialId: Base64URL-encoded credential identifier, or `nil` for a
+    ///     headless connection bound to the contract alone.
     ///   - contractId: Smart account contract address.
-    func setConnectedState(credentialId: String, contractId: String)
+    func setConnectedState(credentialId: String?, contractId: String)
 
     /// Signer manager bound to this kit. Exposed through the protocol so
     /// sibling managers and tests can resolve it without holding a typed

--- a/stellarsdk/stellarsdk/smartaccount/oz/OZSmartAccountKitProtocol.swift
+++ b/stellarsdk/stellarsdk/smartaccount/oz/OZSmartAccountKitProtocol.swift
@@ -27,6 +27,13 @@ internal struct ConnectedState: Sendable, Equatable, Hashable {
         self.credentialId = credentialId
         self.contractId = contractId
     }
+
+    /// `true` when this state was produced by a headless
+    /// ``OZWalletOperations/connectToContract(contractId:)`` connection, which
+    /// records ``OZConstants/headlessCredentialIdSentinel`` in place of a real
+    /// passkey credential. The single-passkey submit path consults this to
+    /// reject headless callers up front.
+    var isHeadless: Bool { credentialId == OZConstants.headlessCredentialIdSentinel }
 }
 
 // MARK: - Credential Manager Protocol

--- a/stellarsdk/stellarsdk/smartaccount/oz/OZTransactionOperations.swift
+++ b/stellarsdk/stellarsdk/smartaccount/oz/OZTransactionOperations.swift
@@ -326,6 +326,19 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
         resolveContextRuleIds: OZResolveContextRuleIds? = nil
     ) async throws -> OZTransactionResult {
         let connected = try kit.requireConnected()
+        // why: a headless connection records the empty credential sentinel and
+        // is operable only through the multi-signer / external-signer pipeline.
+        // The single-passkey path below reads `connected.credentialId`; refuse
+        // it up front so a misrouted headless call fails clearly here rather
+        // than late and confusingly inside the credential lookup or the
+        // WebAuthn-provider guard.
+        if connected.isHeadless {
+            throw SmartAccountValidationException.invalidInput(
+                field: "selectedSigners",
+                reason: "This kit is connected headlessly (no passkey); use the " +
+                    "multi-signer pipeline with explicit selectedSigners for headless operations."
+            )
+        }
         let deployer = try await kit.getDeployer()
         let deployerAccount = try await fetchAccount(accountId: deployer.accountId)
 

--- a/stellarsdk/stellarsdk/smartaccount/oz/OZTransactionOperations.swift
+++ b/stellarsdk/stellarsdk/smartaccount/oz/OZTransactionOperations.swift
@@ -326,13 +326,14 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
         resolveContextRuleIds: OZResolveContextRuleIds? = nil
     ) async throws -> OZTransactionResult {
         let connected = try kit.requireConnected()
-        // why: a headless connection records the empty credential sentinel and
-        // is operable only through the multi-signer / external-signer pipeline.
-        // The single-passkey path below reads `connected.credentialId`; refuse
-        // it up front so a misrouted headless call fails clearly here rather
-        // than late and confusingly inside the credential lookup or the
+        // why: a headless connection carries no passkey credential
+        // (credentialId == nil) and is operable only through the multi-signer /
+        // external-signer pipeline. The single-passkey path below requires a
+        // credential, so refuse a headless caller up front — binding the
+        // credential in the same step — so a misrouted call fails clearly here
+        // rather than late and confusingly inside the credential lookup or the
         // WebAuthn-provider guard.
-        if connected.isHeadless {
+        guard let credentialId = connected.credentialId else {
             throw SmartAccountValidationException.invalidInput(
                 field: "selectedSigners",
                 reason: "This kit is connected headlessly (no passkey); use the " +
@@ -360,13 +361,14 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
         let signedAuthEntries = try await signAuthEntriesPass(
             simulatedAuthEntries: simulatedAuthEntries,
             connected: connected,
+            credentialId: credentialId,
             resolveContextRuleIds: resolveContextRuleIds
         )
 
         if !signedAuthEntries.isEmpty {
             do {
                 try await kit.credentialManagerProtocol.updateLastUsed(
-                    credentialId: connected.credentialId
+                    credentialId: credentialId
                 )
             } catch {
                 // best-effort; the credential update is non-critical
@@ -407,6 +409,8 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
     /// - Parameters:
     ///   - simulatedAuthEntries: Entries returned from the initial simulation.
     ///   - connected: Active connected-state pair identifying the smart account.
+    ///   - credentialId: Base64URL-encoded passkey credential id of the connected
+    ///     wallet, resolved by the caller after the headless guard.
     ///   - resolveContextRuleIds: Optional override of the automatic context-rule
     ///     resolution.
     /// - Returns: Authorization entries with the OZ AuthPayload Map wired into
@@ -416,6 +420,7 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
     private func signAuthEntriesPass(
         simulatedAuthEntries: [SorobanAuthorizationEntryXDR],
         connected: ConnectedState,
+        credentialId: String,
         resolveContextRuleIds: OZResolveContextRuleIds?
     ) async throws -> [SorobanAuthorizationEntryXDR] {
         if simulatedAuthEntries.isEmpty {
@@ -493,10 +498,10 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
 
             let credIdBytes: Data
             do {
-                credIdBytes = try Data(base64URLEncoded: connected.credentialId)
+                credIdBytes = try Data(base64URLEncoded: credentialId)
             } catch {
                 throw SmartAccountCredentialException.invalid(
-                    reason: "Failed to decode credentialId from Base64URL: \(connected.credentialId)",
+                    reason: "Failed to decode credentialId from Base64URL: \(credentialId)",
                     cause: error
                 )
             }
@@ -505,7 +510,7 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
             // the active context rules are scanned for an External signer whose
             // key suffix matches the decoded credential id.
             let stored: OZStoredCredential? = await safeGetCredential(
-                credentialId: connected.credentialId
+                credentialId: credentialId
             )
             let signer: OZExternalSigner
             if let stored = stored {
@@ -845,6 +850,83 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
         return OZTransactionOperations.formatXlmAmount(stroops: transferStroops)
     }
 
+    /// Outcome of a single visibility probe issued by
+    /// ``pollUntilVisible(pollIntervalMs:timeoutSeconds:probe:timeoutReason:)``.
+    private enum PollOutcome<T> {
+        /// The probed ledger entry is visible; carries the resolved payload the
+        /// wait returns.
+        case visible(T)
+        /// The entry is not yet applied on the ledger the RPC has observed; the
+        /// poll continues.
+        case notYetVisible
+        /// The probe failed for a transport reason; retained as the eventual
+        /// timeout cause while the poll continues.
+        case transient(SorobanRpcRequestError)
+    }
+
+    /// Polls a Soroban-RPC visibility probe on a fixed interval until it reports
+    /// the target ledger entry as visible, then returns the probe's payload.
+    ///
+    /// A freshly funded account or freshly deployed contract confirms on Horizon
+    /// within milliseconds, but the Soroban RPC may not observe the new ledger
+    /// entry until a later ledger close; polling absorbs that variable
+    /// propagation delay rather than assuming a single fixed wait. Each `probe`
+    /// round trip is classified as ``PollOutcome/visible(_:)`` (the wait returns
+    /// the carried payload), ``PollOutcome/notYetVisible`` (the entry is not yet
+    /// applied, so another poll is issued), or ``PollOutcome/transient(_:)`` (a
+    /// transport failure retained as the eventual timeout cause). Every transient
+    /// error is retained and surfaced as the timeout cause when the entry never
+    /// becomes visible. The deadline is measured against a monotonic clock so it
+    /// cannot be perturbed by wall-clock adjustments while the wait is in flight.
+    /// The wait is cooperatively cancellable through Swift task cancellation.
+    ///
+    /// - Parameters:
+    ///   - pollIntervalMs: Delay between probes in milliseconds, clamped to a
+    ///     minimum of 1 ms to avoid a busy-loop.
+    ///   - timeoutSeconds: Overall budget in seconds.
+    ///   - probe: The per-attempt visibility probe.
+    ///   - timeoutReason: Builds the timeout message from the elapsed budget and
+    ///     the last transient error, when any was retained.
+    /// - Returns: The payload carried by the first ``PollOutcome/visible(_:)``.
+    /// - Throws: ``SmartAccountTransactionException/Timeout`` when the entry is
+    ///   not visible within `timeoutSeconds`; `CancellationError` when the
+    ///   surrounding task is cancelled.
+    private func pollUntilVisible<T>(
+        pollIntervalMs: Int,
+        timeoutSeconds: Double,
+        probe: () async -> PollOutcome<T>,
+        timeoutReason: (_ seconds: Double, _ lastError: SorobanRpcRequestError?) -> String
+    ) async throws -> T {
+        let pollIntervalNanos = UInt64(max(1, pollIntervalMs)) * 1_000_000
+        // Monotonic deadline: DispatchTime advances independently of wall-clock
+        // changes, so a clock adjustment cannot shorten or extend the budget.
+        let deadline = DispatchTime.now() + timeoutSeconds
+        var lastTransientError: SorobanRpcRequestError?
+
+        while true {
+            try Task.checkCancellation()
+
+            switch await probe() {
+            case .visible(let payload):
+                return payload
+            case .notYetVisible:
+                break
+            case .transient(let error):
+                lastTransientError = error
+            }
+
+            if DispatchTime.now() >= deadline {
+                break
+            }
+            try await Task.sleep(nanoseconds: pollIntervalNanos)
+        }
+
+        throw SmartAccountTransactionException.timeout(
+            details: timeoutReason(timeoutSeconds, lastTransientError),
+            cause: lastTransientError
+        )
+    }
+
     /// Polls the Soroban RPC for a Friendbot-funded temporary account's ledger
     /// entry until it is visible, then returns the resolved account.
     ///
@@ -853,8 +935,9 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
     /// ledger close. Simulating the native SAC's `balance(<temp account>)`
     /// before the entry is visible fails with `Error(Contract, #6)`
     /// "account entry is missing"; this poll gates the balance simulation on the
-    /// account actually being present, replacing a single fixed propagation
-    /// delay that fails under slower-than-expected testnet propagation.
+    /// account actually being present rather than assuming a single fixed
+    /// propagation delay, which fails when testnet propagation is slower than
+    /// the assumed wait.
     ///
     /// ``SorobanServer/getAccount(accountId:)`` reports a not-yet-visible
     /// account as a `.requestFailed` carrying
@@ -870,7 +953,8 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
     ///   - pollIntervalMs: Delay between polls in milliseconds, clamped to a
     ///     minimum of 1 ms to avoid a busy-loop. Defaults to
     ///     ``OZConstants/rpcVisibilityPollIntervalMs``.
-    ///   - timeoutSeconds: Overall wall-clock budget in seconds. Defaults to
+    ///   - timeoutSeconds: Overall budget in seconds, measured against a
+    ///     monotonic clock. Defaults to
     ///     ``OZConstants/rpcVisibilityTimeoutSeconds``.
     /// - Returns: The funding account, now visible to the Soroban RPC, with its
     ///   current sequence number.
@@ -882,42 +966,33 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
         pollIntervalMs: Int = OZConstants.rpcVisibilityPollIntervalMs,
         timeoutSeconds: Double = Double(OZConstants.rpcVisibilityTimeoutSeconds)
     ) async throws -> Account {
-        let pollIntervalNanos = UInt64(max(1, pollIntervalMs)) * 1_000_000
-        let deadline = Date().addingTimeInterval(timeoutSeconds)
-        var lastTransientError: SorobanRpcRequestError?
-
-        while true {
-            try Task.checkCancellation()
-
-            switch await kit.sorobanServer.getAccount(accountId: accountId) {
-            case .success(let account):
-                return account
-            case .failure(let error):
-                // "account not found yet" is the expected propagation case and
-                // simply drives another poll; every other failure is a
-                // transient RPC error retained as the eventual timeout cause.
-                if !OZTransactionOperations.isAccountNotVisibleError(error) {
-                    lastTransientError = error
+        return try await pollUntilVisible(
+            pollIntervalMs: pollIntervalMs,
+            timeoutSeconds: timeoutSeconds,
+            probe: { () -> PollOutcome<Account> in
+                switch await kit.sorobanServer.getAccount(accountId: accountId) {
+                case .success(let account):
+                    return .visible(account)
+                case .failure(let error):
+                    // "account not found yet" is the expected propagation case
+                    // and simply drives another poll; every other failure is a
+                    // transient RPC error retained as the eventual timeout cause.
+                    return OZTransactionOperations.isAccountNotVisibleError(error)
+                        ? .notYetVisible
+                        : .transient(error)
                 }
+            },
+            timeoutReason: { seconds, lastError in
+                let timeoutText = OZTransactionOperations.describeSeconds(seconds)
+                var reason =
+                    "Funding account \(accountId) not visible to the Soroban RPC within " +
+                    "\(timeoutText)s after Friendbot funding; testnet propagation may be " +
+                    "delayed. Retry shortly."
+                if let lastError = lastError {
+                    reason += " Last RPC error: \(self.rpcErrorMessage(lastError))."
+                }
+                return reason
             }
-
-            if Date() >= deadline {
-                break
-            }
-            try await Task.sleep(nanoseconds: pollIntervalNanos)
-        }
-
-        let timeoutText = OZTransactionOperations.describeSeconds(timeoutSeconds)
-        var reason =
-            "Funding account \(accountId) not visible to the Soroban RPC within " +
-            "\(timeoutText)s after Friendbot funding; testnet propagation may be " +
-            "delayed. Retry shortly."
-        if let lastTransientError = lastTransientError {
-            reason += " Last RPC error: \(rpcErrorMessage(lastTransientError))."
-        }
-        throw SmartAccountTransactionException.timeout(
-            details: reason,
-            cause: lastTransientError
         )
     }
 
@@ -928,8 +1003,9 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
     /// Soroban RPC's simulation endpoint observes the new contract instance.
     /// Simulating the funding flow against the contract before its instance
     /// entry is visible fails; this poll gates the funding flow on the contract
-    /// actually being present, replacing a single fixed propagation delay that
-    /// fails under slower-than-expected testnet propagation.
+    /// actually being present rather than assuming a single fixed propagation
+    /// delay, which fails when testnet propagation is slower than the assumed
+    /// wait.
     ///
     /// Visibility is detected structurally, without string-matching:
     /// ``SorobanServer/getLedgerEntries(base64EncodedKeys:)`` is queried for the
@@ -950,7 +1026,8 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
     ///   - pollIntervalMs: Delay between polls in milliseconds, clamped to a
     ///     minimum of 1 ms to avoid a busy-loop. Defaults to
     ///     ``OZConstants/rpcVisibilityPollIntervalMs``.
-    ///   - timeoutSeconds: Overall wall-clock budget in seconds. Defaults to
+    ///   - timeoutSeconds: Overall budget in seconds, measured against a
+    ///     monotonic clock. Defaults to
     ///     ``OZConstants/rpcVisibilityTimeoutSeconds``.
     /// - Throws: ``SmartAccountTransactionException/Timeout`` when the contract
     ///   is not visible within `timeoutSeconds`;
@@ -965,48 +1042,37 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
         let ledgerKeyBase64 = try OZTransactionOperations.contractInstanceLedgerKey(
             contractId: contractId
         )
-        let pollIntervalNanos = UInt64(max(1, pollIntervalMs)) * 1_000_000
-        let deadline = Date().addingTimeInterval(timeoutSeconds)
-        var lastTransientError: SorobanRpcRequestError?
-
-        while true {
-            try Task.checkCancellation()
-
-            switch await kit.sorobanServer.getLedgerEntries(
-                base64EncodedKeys: [ledgerKeyBase64]
-            ) {
-            case .success(let response):
-                // A present instance entry means the RPC has applied the ledger
-                // carrying the deployed contract; an empty result is the
-                // structural "not visible yet" signal and simply drives another
-                // poll.
-                if !response.entries.isEmpty {
-                    return
+        _ = try await pollUntilVisible(
+            pollIntervalMs: pollIntervalMs,
+            timeoutSeconds: timeoutSeconds,
+            probe: { () -> PollOutcome<Void> in
+                switch await kit.sorobanServer.getLedgerEntries(
+                    base64EncodedKeys: [ledgerKeyBase64]
+                ) {
+                case .success(let response):
+                    // A present instance entry means the RPC has applied the
+                    // ledger carrying the deployed contract; an empty result is
+                    // the structural "not visible yet" signal that drives another
+                    // poll.
+                    return response.entries.isEmpty ? .notYetVisible : .visible(())
+                case .failure(let error):
+                    // Every RPC transport failure is a transient error retained
+                    // as the eventual timeout cause; the not-visible signal is
+                    // the empty-entries success above, never a failure.
+                    return .transient(error)
                 }
-            case .failure(let error):
-                // Every RPC transport failure is a transient error retained as
-                // the eventual timeout cause; the not-visible signal is the
-                // empty-entries success above, never a failure.
-                lastTransientError = error
+            },
+            timeoutReason: { seconds, lastError in
+                let timeoutText = OZTransactionOperations.describeSeconds(seconds)
+                var reason =
+                    "Deployed contract \(contractId) not visible to the Soroban RPC " +
+                    "within \(timeoutText)s after deployment; testnet propagation may " +
+                    "be delayed. Retry shortly."
+                if let lastError = lastError {
+                    reason += " Last RPC error: \(self.rpcErrorMessage(lastError))."
+                }
+                return reason
             }
-
-            if Date() >= deadline {
-                break
-            }
-            try await Task.sleep(nanoseconds: pollIntervalNanos)
-        }
-
-        let timeoutText = OZTransactionOperations.describeSeconds(timeoutSeconds)
-        var reason =
-            "Deployed contract \(contractId) not visible to the Soroban RPC " +
-            "within \(timeoutText)s after deployment; testnet propagation may " +
-            "be delayed. Retry shortly."
-        if let lastTransientError = lastTransientError {
-            reason += " Last RPC error: \(rpcErrorMessage(lastTransientError))."
-        }
-        throw SmartAccountTransactionException.timeout(
-            details: reason,
-            cause: lastTransientError
         )
     }
 

--- a/stellarsdk/stellarsdk/smartaccount/oz/OZTransactionOperations.swift
+++ b/stellarsdk/stellarsdk/smartaccount/oz/OZTransactionOperations.swift
@@ -856,9 +856,9 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
     ///   - accountId: The temporary funding account's `G...` address.
     ///   - pollIntervalMs: Delay between polls in milliseconds, clamped to a
     ///     minimum of 1 ms to avoid a busy-loop. Defaults to
-    ///     ``OZConstants/friendbotVisibilityPollIntervalMs``.
+    ///     ``OZConstants/rpcVisibilityPollIntervalMs``.
     ///   - timeoutSeconds: Overall wall-clock budget in seconds. Defaults to
-    ///     ``OZConstants/friendbotVisibilityTimeoutSeconds``.
+    ///     ``OZConstants/rpcVisibilityTimeoutSeconds``.
     /// - Returns: The funding account, now visible to the Soroban RPC, with its
     ///   current sequence number.
     /// - Throws: ``SmartAccountTransactionException/Timeout`` when the account
@@ -866,8 +866,8 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
     ///   surrounding task is cancelled.
     internal func waitForAccountVisibleToRpc(
         accountId: String,
-        pollIntervalMs: Int = OZConstants.friendbotVisibilityPollIntervalMs,
-        timeoutSeconds: Double = Double(OZConstants.friendbotVisibilityTimeoutSeconds)
+        pollIntervalMs: Int = OZConstants.rpcVisibilityPollIntervalMs,
+        timeoutSeconds: Double = Double(OZConstants.rpcVisibilityTimeoutSeconds)
     ) async throws -> Account {
         let pollIntervalNanos = UInt64(max(1, pollIntervalMs)) * 1_000_000
         let deadline = Date().addingTimeInterval(timeoutSeconds)
@@ -906,6 +906,132 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
             details: reason,
             cause: lastTransientError
         )
+    }
+
+    /// Polls the Soroban RPC for a freshly deployed smart-account contract's
+    /// instance ledger entry until it is visible, then returns.
+    ///
+    /// The deploy transaction may confirm on Horizon a ledger or more before the
+    /// Soroban RPC's simulation endpoint observes the new contract instance.
+    /// Simulating the funding flow against the contract before its instance
+    /// entry is visible fails; this poll gates the funding flow on the contract
+    /// actually being present, replacing a single fixed propagation delay that
+    /// fails under slower-than-expected testnet propagation.
+    ///
+    /// Visibility is detected structurally, without string-matching:
+    /// ``SorobanServer/getLedgerEntries(base64EncodedKeys:)`` is queried for the
+    /// contract's persistent instance ledger entry (the ``ContractDataEntryXDR``
+    /// keyed by ``SCValXDR/ledgerKeyContractInstance`` under
+    /// ``ContractDataDurability/persistent``, the exact key the funding flow's
+    /// simulation later reads). An empty `entries` array means the entry is not
+    /// yet applied on the ledger the RPC has observed and drives another poll; a
+    /// present entry means the contract is visible and the wait returns. Any RPC
+    /// transport failure is treated as a transient error: it is retried up to
+    /// the deadline and, when the contract never becomes visible, surfaced as
+    /// the timeout cause. The wait is cooperatively cancellable through Swift
+    /// task cancellation.
+    ///
+    /// - Parameters:
+    ///   - contractId: The deployed smart-account contract address (`C...`
+    ///     strkey).
+    ///   - pollIntervalMs: Delay between polls in milliseconds, clamped to a
+    ///     minimum of 1 ms to avoid a busy-loop. Defaults to
+    ///     ``OZConstants/rpcVisibilityPollIntervalMs``.
+    ///   - timeoutSeconds: Overall wall-clock budget in seconds. Defaults to
+    ///     ``OZConstants/rpcVisibilityTimeoutSeconds``.
+    /// - Throws: ``SmartAccountTransactionException/Timeout`` when the contract
+    ///   is not visible within `timeoutSeconds`;
+    ///   ``SmartAccountValidationException/InvalidAddress`` when `contractId`
+    ///   cannot be encoded into a ledger key; `CancellationError` when the
+    ///   surrounding task is cancelled.
+    internal func waitForContractVisibleToRpc(
+        contractId: String,
+        pollIntervalMs: Int = OZConstants.rpcVisibilityPollIntervalMs,
+        timeoutSeconds: Double = Double(OZConstants.rpcVisibilityTimeoutSeconds)
+    ) async throws {
+        let ledgerKeyBase64 = try OZTransactionOperations.contractInstanceLedgerKey(
+            contractId: contractId
+        )
+        let pollIntervalNanos = UInt64(max(1, pollIntervalMs)) * 1_000_000
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        var lastTransientError: SorobanRpcRequestError?
+
+        while true {
+            try Task.checkCancellation()
+
+            switch await kit.sorobanServer.getLedgerEntries(
+                base64EncodedKeys: [ledgerKeyBase64]
+            ) {
+            case .success(let response):
+                // A present instance entry means the RPC has applied the ledger
+                // carrying the deployed contract; an empty result is the
+                // structural "not visible yet" signal and simply drives another
+                // poll.
+                if !response.entries.isEmpty {
+                    return
+                }
+            case .failure(let error):
+                // Every RPC transport failure is a transient error retained as
+                // the eventual timeout cause; the not-visible signal is the
+                // empty-entries success above, never a failure.
+                lastTransientError = error
+            }
+
+            if Date() >= deadline {
+                break
+            }
+            try await Task.sleep(nanoseconds: pollIntervalNanos)
+        }
+
+        let timeoutText = OZTransactionOperations.describeSeconds(timeoutSeconds)
+        var reason =
+            "Deployed contract \(contractId) not visible to the Soroban RPC " +
+            "within \(timeoutText)s after deployment; testnet propagation may " +
+            "be delayed. Retry shortly."
+        if let lastTransientError = lastTransientError {
+            reason += " Last RPC error: \(rpcErrorMessage(lastTransientError))."
+        }
+        throw SmartAccountTransactionException.timeout(
+            details: reason,
+            cause: lastTransientError
+        )
+    }
+
+    /// Builds the Base64-encoded `LedgerKey` for a contract's persistent
+    /// instance ledger entry: the ``ContractDataEntryXDR`` keyed by
+    /// ``SCValXDR/ledgerKeyContractInstance`` under
+    /// ``ContractDataDurability/persistent``. This is the entry the Soroban RPC
+    /// reports for a deployed contract; probing it via
+    /// ``SorobanServer/getLedgerEntries(base64EncodedKeys:)`` is the visibility
+    /// signal for ``waitForContractVisibleToRpc(contractId:pollIntervalMs:timeoutSeconds:)``.
+    ///
+    /// Mirrors the key ``SorobanServer/getContractData(contractId:key:durability:)``
+    /// constructs internally so the visibility probe queries the exact entry the
+    /// funding flow's simulation later reads.
+    ///
+    /// - Throws: ``SmartAccountValidationException/InvalidAddress`` when
+    ///   `contractId` is not a valid contract address or its ledger key cannot
+    ///   be XDR-encoded.
+    internal static func contractInstanceLedgerKey(contractId: String) throws -> String {
+        let contractAddress: SCAddressXDR
+        do {
+            contractAddress = try SCAddressXDR(contractId: contractId)
+        } catch {
+            throw SmartAccountValidationException.invalidAddress(
+                address: contractId,
+                cause: error
+            )
+        }
+        let contractDataKey = LedgerKeyContractDataXDR(
+            contract: contractAddress,
+            key: .ledgerKeyContractInstance,
+            durability: .persistent
+        )
+        let ledgerKey = LedgerKeyXDR.contractData(contractDataKey)
+        guard let ledgerKeyBase64 = ledgerKey.xdrEncoded else {
+            throw SmartAccountValidationException.invalidAddress(address: contractId)
+        }
+        return ledgerKeyBase64
     }
 
     /// Simulates a host function in isolation and returns the parsed `SCValXDR`

--- a/stellarsdk/stellarsdk/smartaccount/oz/OZTransactionOperations.swift
+++ b/stellarsdk/stellarsdk/smartaccount/oz/OZTransactionOperations.swift
@@ -696,13 +696,17 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
             )
         }
 
-        // why: wait for Friendbot propagation to Soroban RPC state. The
-        // Horizon submission confirms in milliseconds but Soroban RPC may not
-        // observe the new account ledger entry until the next ledger close
-        // (~5 seconds on testnet).
-        try await Task.sleep(nanoseconds: 5_000_000_000)
-
-        let tempAccount = try await fetchAccount(accountId: tempKeypair.accountId)
+        // why: Friendbot confirms on Horizon within milliseconds, but the
+        // Soroban RPC may not observe the new account's ledger entry until a
+        // later ledger close. Poll the RPC until the temp account is visible
+        // rather than assuming a single fixed propagation delay; a fixed wait
+        // fails whenever testnet propagation is slower than the guess, because
+        // the balance simulation below would then read a not-yet-applied
+        // account entry and throw `Error(Contract, #6)` "account entry is
+        // missing".
+        let tempAccount = try await waitForAccountVisibleToRpc(
+            accountId: tempKeypair.accountId
+        )
 
         let reserveStroopsInt64: Int64 =
             Int64(OZConstants.friendbotReserveXlm) * StellarProtocolConstants.stroopsPerXlm
@@ -826,6 +830,82 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
         }
 
         return OZTransactionOperations.formatXlmAmount(stroops: transferStroops)
+    }
+
+    /// Polls the Soroban RPC for a Friendbot-funded temporary account's ledger
+    /// entry until it is visible, then returns the resolved account.
+    ///
+    /// Friendbot confirms the funding on Horizon within milliseconds, but the
+    /// Soroban RPC may not observe the new account's ledger entry until a later
+    /// ledger close. Simulating the native SAC's `balance(<temp account>)`
+    /// before the entry is visible fails with `Error(Contract, #6)`
+    /// "account entry is missing"; this poll gates the balance simulation on the
+    /// account actually being present, replacing a single fixed propagation
+    /// delay that fails under slower-than-expected testnet propagation.
+    ///
+    /// ``SorobanServer/getAccount(accountId:)`` reports a not-yet-visible
+    /// account as a `.requestFailed` carrying
+    /// ``SorobanServer/accountNotFoundMessage``; that outcome drives another
+    /// poll. Any other RPC failure is treated as a transient error: it is
+    /// retried up to the deadline and, when the account never becomes visible,
+    /// surfaced as the timeout cause. The successfully resolved account is
+    /// returned so the caller can reuse it without a second round-trip. The
+    /// wait is cooperatively cancellable through Swift task cancellation.
+    ///
+    /// - Parameters:
+    ///   - accountId: The temporary funding account's `G...` address.
+    ///   - pollIntervalMs: Delay between polls in milliseconds, clamped to a
+    ///     minimum of 1 ms to avoid a busy-loop. Defaults to
+    ///     ``OZConstants/friendbotVisibilityPollIntervalMs``.
+    ///   - timeoutSeconds: Overall wall-clock budget in seconds. Defaults to
+    ///     ``OZConstants/friendbotVisibilityTimeoutSeconds``.
+    /// - Returns: The funding account, now visible to the Soroban RPC, with its
+    ///   current sequence number.
+    /// - Throws: ``SmartAccountTransactionException/Timeout`` when the account
+    ///   is not visible within `timeoutSeconds`; `CancellationError` when the
+    ///   surrounding task is cancelled.
+    internal func waitForAccountVisibleToRpc(
+        accountId: String,
+        pollIntervalMs: Int = OZConstants.friendbotVisibilityPollIntervalMs,
+        timeoutSeconds: Double = Double(OZConstants.friendbotVisibilityTimeoutSeconds)
+    ) async throws -> Account {
+        let pollIntervalNanos = UInt64(max(1, pollIntervalMs)) * 1_000_000
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        var lastTransientError: SorobanRpcRequestError?
+
+        while true {
+            try Task.checkCancellation()
+
+            switch await kit.sorobanServer.getAccount(accountId: accountId) {
+            case .success(let account):
+                return account
+            case .failure(let error):
+                // "account not found yet" is the expected propagation case and
+                // simply drives another poll; every other failure is a
+                // transient RPC error retained as the eventual timeout cause.
+                if !OZTransactionOperations.isAccountNotVisibleError(error) {
+                    lastTransientError = error
+                }
+            }
+
+            if Date() >= deadline {
+                break
+            }
+            try await Task.sleep(nanoseconds: pollIntervalNanos)
+        }
+
+        let timeoutText = OZTransactionOperations.describeSeconds(timeoutSeconds)
+        var reason =
+            "Funding account \(accountId) not visible to the Soroban RPC within " +
+            "\(timeoutText)s after Friendbot funding; testnet propagation may be " +
+            "delayed. Retry shortly."
+        if let lastTransientError = lastTransientError {
+            reason += " Last RPC error: \(rpcErrorMessage(lastTransientError))."
+        }
+        throw SmartAccountTransactionException.timeout(
+            details: reason,
+            cause: lastTransientError
+        )
     }
 
     /// Simulates a host function in isolation and returns the parsed `SCValXDR`
@@ -1428,6 +1508,30 @@ public final class OZTransactionOperations: OZManagerHelpers, @unchecked Sendabl
             return nil
         }
         return nil
+    }
+
+    /// Returns `true` when a ``SorobanServer/getAccount(accountId:)`` failure
+    /// denotes an account not yet present on the ledger applied by the RPC,
+    /// rather than a transport or protocol error. `getAccount` reports a missing
+    /// account entry as a `.requestFailed` carrying
+    /// ``SorobanServer/accountNotFoundMessage``; matching that single shared
+    /// constant keeps this classification in lockstep with the message
+    /// `getAccount` actually emits. Every other failure shape is treated as a
+    /// transient RPC error.
+    internal static func isAccountNotVisibleError(_ error: SorobanRpcRequestError) -> Bool {
+        if case .requestFailed(let message) = error {
+            return message == SorobanServer.accountNotFoundMessage
+        }
+        return false
+    }
+
+    /// Formats a seconds value for human-readable error text, dropping the
+    /// fractional component when the value is a whole number of seconds.
+    internal static func describeSeconds(_ seconds: Double) -> String {
+        if seconds == seconds.rounded(.towardZero) {
+            return String(Int(seconds))
+        }
+        return String(seconds)
     }
 
     /// Extracts a `UInt32` from an `SCValXDR.u32` value, used to parse a token

--- a/stellarsdk/stellarsdk/smartaccount/oz/OZWalletOperations.swift
+++ b/stellarsdk/stellarsdk/smartaccount/oz/OZWalletOperations.swift
@@ -398,6 +398,7 @@ public final class OZWalletOperations: OZManagerHelpers, @unchecked Sendable {
         if autoSubmit {
             transactionHash = try await signAndSubmitDeploy(
                 deployTransaction: built.transaction,
+                contractId: contractId,
                 credentialIdBase64url: credentialIdBase64url,
                 autoFund: autoFund,
                 nativeTokenContract: nativeTokenContract,
@@ -482,6 +483,9 @@ public final class OZWalletOperations: OZManagerHelpers, @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - deployTransaction: Built and signed deploy transaction.
+    ///   - contractId: Deterministic address of the contract this deploy
+    ///     creates; used to gate funding on the contract becoming visible to
+    ///     the Soroban RPC.
     ///   - credentialIdBase64url: Base64URL-encoded credential identifier for
     ///     credential-manager bookkeeping.
     ///   - autoFund: Whether to fund the wallet via Friendbot after the deploy
@@ -493,6 +497,7 @@ public final class OZWalletOperations: OZManagerHelpers, @unchecked Sendable {
     ///   ``WebAuthnException``.
     private func signAndSubmitDeploy(
         deployTransaction: Transaction,
+        contractId: String,
         credentialIdBase64url: String,
         autoFund: Bool,
         nativeTokenContract: String?,
@@ -512,10 +517,15 @@ public final class OZWalletOperations: OZManagerHelpers, @unchecked Sendable {
                 )
             }
             // why: the deploy transaction may be confirmed on Horizon before
-            // Soroban RPC's simulation endpoint observes the new contract
-            // instance; wait for the next ledger close (~5s on testnet) before
-            // the funding flow simulates against the contract.
-            try await Task.sleep(nanoseconds: 5_000_000_000)
+            // the Soroban RPC's simulation endpoint observes the new contract
+            // instance; poll the RPC until the contract's instance ledger entry
+            // is visible rather than assuming a single fixed propagation delay,
+            // which fails whenever testnet propagation is slower than the guess
+            // and the funding flow then simulates against a not-yet-applied
+            // contract.
+            try await transactionOperations.waitForContractVisibleToRpc(
+                contractId: contractId
+            )
             _ = try await transactionOperations.fundWallet(
                 nativeTokenContract: tokenContract,
                 forceMethod: forceMethod
@@ -1002,7 +1012,16 @@ public final class OZWalletOperations: OZManagerHelpers, @unchecked Sendable {
                     reason: "nativeTokenContract is required when autoFund is true"
                 )
             }
-            try await Task.sleep(nanoseconds: 5_000_000_000)
+            // why: the deploy transaction may be confirmed on Horizon before
+            // the Soroban RPC's simulation endpoint observes the new contract
+            // instance; poll the RPC until the contract's instance ledger entry
+            // is visible rather than assuming a single fixed propagation delay,
+            // which fails whenever testnet propagation is slower than the guess
+            // and the funding flow then simulates against a not-yet-applied
+            // contract.
+            try await transactionOperations.waitForContractVisibleToRpc(
+                contractId: contractId
+            )
             _ = try await transactionOperations.fundWallet(
                 nativeTokenContract: tokenContract,
                 forceMethod: forceMethod

--- a/stellarsdk/stellarsdk/smartaccount/oz/OZWalletOperations.swift
+++ b/stellarsdk/stellarsdk/smartaccount/oz/OZWalletOperations.swift
@@ -101,6 +101,20 @@ public struct OZDeployPendingResult: Sendable, Equatable, Hashable {
     }
 }
 
+/// Outcome of a headless ``OZWalletOperations/connectToContract(contractId:)``.
+///
+/// Carries the verified smart-account contract address. No credential is
+/// involved in a headless connection.
+public struct OZConnectToContractResult: Sendable, Equatable, Hashable {
+
+    /// Smart account contract address (`C…` strkey) the kit connected to.
+    public let contractId: String
+
+    public init(contractId: String) {
+        self.contractId = contractId
+    }
+}
+
 /// Outcome of a connect-wallet operation.
 ///
 /// `connectWallet(options:)` returns one of three results:
@@ -746,6 +760,56 @@ public final class OZWalletOperations: OZManagerHelpers, @unchecked Sendable {
         )
     }
 
+    /// Connects the kit to an already-deployed smart account by contract address,
+    /// with no passkey credential.
+    ///
+    /// Intended for headless callers — an autonomous signer (the reference agent)
+    /// or a backend service — that operate the account through the multi-signer /
+    /// external-signer pipeline (non-empty `selectedSigners`) and never present a
+    /// passkey. Unlike ``connectWallet(options:)``, this does not run a WebAuthn
+    /// ceremony, does not consult the credential manager, and does not persist a
+    /// session; it also clears any previously saved session so a later silent
+    /// reconnect cannot resurrect a stale passkey session.
+    ///
+    /// After a headless connect the single-passkey paths
+    /// (``OZTransactionOperations/submit(hostFunction:auth:forceMethod:resolveContextRuleIds:)``,
+    /// ``OZTransactionOperations/transfer(tokenContract:recipient:amount:decimals:forceMethod:)``,
+    /// ``OZTransactionOperations/contractCall(target:targetFn:targetArgs:forceMethod:resolveContextRuleIds:)``,
+    /// ``OZTransactionOperations/executeAndSubmit(target:targetFn:targetArgs:forceMethod:resolveContextRuleIds:)``,
+    /// and any manager call left at the default empty `selectedSigners`) are NOT
+    /// usable: they require a passkey credential and throw a clear error from the
+    /// headless guard. Operate through `kit.multiSignerManager` or the sibling
+    /// managers with an explicit non-empty `selectedSigners` list.
+    ///
+    /// The contract address is validated and its on-chain existence is verified
+    /// before the connected state is set.
+    ///
+    /// - Parameter contractId: Smart account contract address (`C…` strkey).
+    /// - Returns: ``OZConnectToContractResult`` carrying the verified `contractId`.
+    /// - Throws: ``SmartAccountValidationException/InvalidAddress`` when `contractId`
+    ///   is not a valid contract address; ``SmartAccountWalletException/NotFound``
+    ///   when no contract instance exists at the address;
+    ///   ``SmartAccountTransactionException`` when the RPC existence check fails for
+    ///   transport reasons.
+    public func connectToContract(contractId: String) async throws -> OZConnectToContractResult {
+        try requireContractAddress(contractId, fieldName: "contractId")
+
+        try await verifyContractExists(contractId: contractId)
+
+        // Drop any pre-existing passkey session so a later silent
+        // `connectWallet()` restore cannot resurrect a state that contradicts
+        // the in-memory headless connection. Best-effort by design.
+        await safeClearSession()
+
+        kit.setConnectedState(
+            credentialId: OZConstants.headlessCredentialIdSentinel,
+            contractId: contractId
+        )
+        kit.events.emit(.walletConnectedHeadless(contractId: contractId))
+
+        return OZConnectToContractResult(contractId: contractId)
+    }
+
     /// Authenticates with a passkey without connecting to a wallet.
     ///
     /// Used to authenticate the user before contract selection (for example to
@@ -1064,11 +1128,37 @@ public final class OZWalletOperations: OZManagerHelpers, @unchecked Sendable {
             )
         }
 
+        // A blank credential id collides with the headless sentinel
+        // (``OZConstants/headlessCredentialIdSentinel``). Reject it so a passkey
+        // connect can never produce a sentinel-equal connected state and trip
+        // the headless guard on the single-passkey submit path. Headless
+        // callers use ``connectToContract(contractId:)`` instead.
+        if let credentialId = credentialId,
+           credentialId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            throw SmartAccountValidationException.invalidInput(
+                field: "credentialId",
+                reason: "credentialId must not be empty or blank"
+            )
+        }
+
         // Normalise caller-supplied Base64URL credential id by stripping any
         // trailing `=` padding so storage-key lookups, connected-state writes,
         // event payloads, and the saved session all use the canonical unpadded
         // form produced by ``Data.base64URLEncodedString()``.
         let credentialId = credentialId.map(OZSmartAccountBuilders.strippedBase64URLPadding)
+
+        // A pure-padding credential id (for example "==") is neither empty nor
+        // whitespace, so it slips past the blank check above, yet padding
+        // stripping collapses it to the empty headless sentinel here. Reject the
+        // normalised-empty form too so the empty credential id stays reserved
+        // for the headless path and a passkey connect can never adopt the
+        // sentinel and trip the headless guard on the single-passkey submit path.
+        if let credentialId = credentialId, credentialId.isEmpty {
+            throw SmartAccountValidationException.invalidInput(
+                field: "credentialId",
+                reason: "credentialId must not be empty or blank"
+            )
+        }
 
         var finalContractId: String? = contractId
 

--- a/stellarsdk/stellarsdk/smartaccount/oz/OZWalletOperations.swift
+++ b/stellarsdk/stellarsdk/smartaccount/oz/OZWalletOperations.swift
@@ -802,7 +802,7 @@ public final class OZWalletOperations: OZManagerHelpers, @unchecked Sendable {
         await safeClearSession()
 
         kit.setConnectedState(
-            credentialId: OZConstants.headlessCredentialIdSentinel,
+            credentialId: nil,
             contractId: contractId
         )
         kit.events.emit(.walletConnectedHeadless(contractId: contractId))
@@ -1128,11 +1128,10 @@ public final class OZWalletOperations: OZManagerHelpers, @unchecked Sendable {
             )
         }
 
-        // A blank credential id collides with the headless sentinel
-        // (``OZConstants/headlessCredentialIdSentinel``). Reject it so a passkey
-        // connect can never produce a sentinel-equal connected state and trip
-        // the headless guard on the single-passkey submit path. Headless
-        // callers use ``connectToContract(contractId:)`` instead.
+        // An empty credential id is not a valid WebAuthn credential. Reject a
+        // blank or whitespace-only id up front so the cascade only ever runs
+        // against a real Base64URL credential. Headless callers use
+        // ``connectToContract(contractId:)`` instead.
         if let credentialId = credentialId,
            credentialId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             throw SmartAccountValidationException.invalidInput(
@@ -1149,10 +1148,9 @@ public final class OZWalletOperations: OZManagerHelpers, @unchecked Sendable {
 
         // A pure-padding credential id (for example "==") is neither empty nor
         // whitespace, so it slips past the blank check above, yet padding
-        // stripping collapses it to the empty headless sentinel here. Reject the
-        // normalised-empty form too so the empty credential id stays reserved
-        // for the headless path and a passkey connect can never adopt the
-        // sentinel and trip the headless guard on the single-passkey submit path.
+        // stripping collapses it to the empty string here. An empty credential
+        // id is not a valid WebAuthn credential, so reject the normalised-empty
+        // form too.
         if let credentialId = credentialId, credentialId.isEmpty {
             throw SmartAccountValidationException.invalidInput(
                 field: "credentialId",

--- a/stellarsdk/stellarsdk/soroban/SorobanServer.swift
+++ b/stellarsdk/stellarsdk/soroban/SorobanServer.swift
@@ -254,6 +254,13 @@ public class SorobanServer: @unchecked Sendable {
     /// HTTP header name for application version identification.
     static let clientApplicationVersionHeader = "X-App-Version"
 
+    /// Message reported by ``getAccount(accountId:)`` when the account's ledger
+    /// entry is absent from the ledger the RPC has applied. Callers that poll
+    /// for eventual account visibility match this single constant instead of a
+    /// duplicated literal, so a wording change here cannot silently reclassify
+    /// a not-found result as a transient transport failure.
+    public static let accountNotFoundMessage = "could not find account"
+
     /// Automatically populated HTTP headers for RPC requests including SDK and application metadata.
     lazy var requestHeaders: [String: String] = {
         var headers: [String: String] = [:]
@@ -665,7 +672,7 @@ public class SorobanServer: @unchecked Sendable {
                         return .success(response: account)
                     }
                     else {
-                        return .failure(error: .requestFailed(message: "could not find account"))
+                        return .failure(error: .requestFailed(message: SorobanServer.accountNotFoundMessage))
                     }
                 case .failure(let error):
                     return .failure(error: error)

--- a/stellarsdk/stellarsdkUnitTests/smartaccount/oz/MockOZSmartAccountKit.swift
+++ b/stellarsdk/stellarsdkUnitTests/smartaccount/oz/MockOZSmartAccountKit.swift
@@ -143,8 +143,8 @@ final class MockOZSmartAccountKit: OZSmartAccountKitProtocol, @unchecked Sendabl
     let storage: OZInMemoryStorageAdapter
 
     /// Records the last `setConnectedState` invocation so tests can assert
-    /// state writes occurred.
-    private(set) var setConnectedStateInvocations: [(credentialId: String, contractId: String)] = []
+    /// state writes occurred. The credential id is `nil` for a headless connection.
+    private(set) var setConnectedStateInvocations: [(credentialId: String?, contractId: String)] = []
 
     // MARK: - Initialization
 
@@ -191,16 +191,15 @@ final class MockOZSmartAccountKit: OZSmartAccountKitProtocol, @unchecked Sendabl
     func requireConnected() throws -> ConnectedState {
         stateLock.lock()
         defer { stateLock.unlock() }
-        guard let credentialId = connectedCredentialId,
-              let contractId = connectedContractId else {
+        guard let contractId = connectedContractId else {
             throw SmartAccountWalletException.notConnected(
                 details: "No wallet connected"
             )
         }
-        return ConnectedState(credentialId: credentialId, contractId: contractId)
+        return ConnectedState(credentialId: connectedCredentialId, contractId: contractId)
     }
 
-    func setConnectedState(credentialId: String, contractId: String) {
+    func setConnectedState(credentialId: String?, contractId: String) {
         stateLock.lock()
         connectedCredentialId = credentialId
         connectedContractId = contractId
@@ -214,11 +213,10 @@ final class MockOZSmartAccountKit: OZSmartAccountKitProtocol, @unchecked Sendabl
     var currentConnectedState: ConnectedState? {
         stateLock.lock()
         defer { stateLock.unlock() }
-        guard let credentialId = connectedCredentialId,
-              let contractId = connectedContractId else {
+        guard let contractId = connectedContractId else {
             return nil
         }
-        return ConnectedState(credentialId: credentialId, contractId: contractId)
+        return ConnectedState(credentialId: connectedCredentialId, contractId: contractId)
     }
 
     var isConnected: Bool {

--- a/stellarsdk/stellarsdkUnitTests/smartaccount/oz/MockSorobanServer.swift
+++ b/stellarsdk/stellarsdkUnitTests/smartaccount/oz/MockSorobanServer.swift
@@ -99,6 +99,13 @@ final class MockSorobanServerScript: @unchecked Sendable {
         scriptLock.lock(); defer { scriptLock.unlock() }
         return _getLedgerEntriesCalls.count
     }
+    /// Raw JSON-RPC `getLedgerEntries` request bodies in call order. Tests
+    /// decode `params.keys` to assert which ledger key was probed (for example
+    /// the contract-instance key the deploy-flow visibility poll queries).
+    var getLedgerEntriesCalls: [Data] {
+        scriptLock.lock(); defer { scriptLock.unlock() }
+        return _getLedgerEntriesCalls
+    }
 
     // MARK: - Script API
 

--- a/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZConnectToContractTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZConnectToContractTests.swift
@@ -117,15 +117,53 @@ final class OZConnectToContractTests: XCTestCase {
         XCTAssertEqual(result.contractId, contractA)
         XCTAssertEqual(h.kit.currentConnectedState?.contractId, contractA)
         XCTAssertEqual(h.kit.setConnectedStateInvocations.last?.contractId, contractA)
-        XCTAssertEqual(
+        XCTAssertNil(
             h.kit.setConnectedStateInvocations.last?.credentialId,
-            "",
-            "headless connect must record the empty credential sentinel"
+            "headless connect must record a nil credential id"
         )
-        XCTAssertEqual(
-            h.kit.currentConnectedState?.credentialId,
-            OZConstants.headlessCredentialIdSentinel
+        XCTAssertNil(h.kit.currentConnectedState?.credentialId)
+        XCTAssertEqual(h.kit.currentConnectedState?.isHeadless, true)
+    }
+
+    /// Drives the headless connect through a REAL ``OZSmartAccountKit`` (not the
+    /// test double) and asserts the public connection surface: the kit reports
+    /// connected, exposes the bound contract id, exposes a nil credential id
+    /// through the public getter, and reports the connection as headless.
+    func test_connectToContract_realKit_exposesHeadlessPublicState() async throws {
+        let storage = OZInMemoryStorageAdapter()
+        let config = try OZSmartAccountConfig(
+            rpcUrl: "https://mock-rpc.invalid/rpc",
+            networkPassphrase: Network.testnet.passphrase,
+            accountWasmHash: "a" + String(repeating: "0", count: 63),
+            webauthnVerifierAddress: contractA,
+            webauthnProvider: nil,
+            storage: storage
         )
+        let kit = OZSmartAccountKit(
+            config: config,
+            storage: storage,
+            sorobanServer: MockSorobanServer.makeMockedSorobanServer(),
+            relayerClient: nil,
+            indexerClient: nil
+        )
+
+        try script.setGetContractDataResponse(contractId: contractA)
+
+        let result = try await kit.walletOperations.connectToContract(contractId: contractA)
+
+        XCTAssertEqual(result.contractId, contractA)
+        XCTAssertTrue(
+            kit.isConnected,
+            "a headless connection must report the real kit as connected"
+        )
+        XCTAssertEqual(kit.contractId, contractA)
+        XCTAssertNil(
+            kit.credentialId,
+            "the public credentialId getter must return nil for a headless connection"
+        )
+        XCTAssertTrue(kit.isHeadless, "a contract-only connection must report as headless")
+
+        await kit.close()
     }
 
     // MARK: - 2. On-chain existence check
@@ -413,15 +451,14 @@ final class OZConnectToContractTests: XCTestCase {
     // MARK: - 11. Real multi-signer pipeline never reads the connected credential
 
     /// Credential boundary, proven against the REAL ``OZMultiSignerManager`` with
-    /// no recording override. After a headless connect records the empty
-    /// credential sentinel, an Ed25519-signed ``multiSignerContractCall`` drives
-    /// the production signing pipeline end-to-end to submission against the
-    /// scripted Soroban server. The pipeline reads only
-    /// ``ConnectedState/contractId`` and never ``ConnectedState/credentialId``,
-    /// so a sentinel-credential connection submits cleanly and `updateLastUsed`
-    /// (the sole consumer of the connected credential) is never invoked. This is
-    /// the practical proof of the boundary that the mocked routing check in
-    /// test 10 cannot give.
+    /// no recording override. After a headless connect records a nil credential,
+    /// an Ed25519-signed ``multiSignerContractCall`` drives the production signing
+    /// pipeline end-to-end to submission against the scripted Soroban server. The
+    /// pipeline reads only ``ConnectedState/contractId`` and never
+    /// ``ConnectedState/credentialId``, so a headless connection submits cleanly
+    /// and `updateLastUsed` (the sole consumer of the connected credential) is
+    /// never invoked. This is the practical proof of the boundary that the mocked
+    /// routing check in test 10 cannot give.
     func test_connectToContract_thenRealMultiSignerPipeline_neverReadsConnectedCredential() async throws {
         let storage = OZInMemoryStorageAdapter()
         let deployer = try deterministicDeployer(seed: 0x5A)
@@ -447,10 +484,14 @@ final class OZConnectToContractTests: XCTestCase {
         //    existence probe (the single getLedgerEntries result).
         try script.setGetContractDataResponse(contractId: contractA)
         _ = try await walletOps.connectToContract(contractId: contractA)
-        XCTAssertEqual(
+        XCTAssertNil(
             kit.currentConnectedState?.credentialId,
-            OZConstants.headlessCredentialIdSentinel,
-            "precondition: the connection must hold the empty credential sentinel"
+            "precondition: a headless connection must hold no credential id"
+        )
+        XCTAssertEqual(
+            kit.currentConnectedState?.isHeadless,
+            true,
+            "precondition: the connection must be headless"
         )
 
         // 2) Register an in-memory Ed25519 external signer whose verifier is the
@@ -494,7 +535,7 @@ final class OZConnectToContractTests: XCTestCase {
 
         XCTAssertTrue(
             result.success,
-            "the multi-signer pipeline must submit cleanly on a sentinel-credential " +
+            "the multi-signer pipeline must submit cleanly on a headless " +
                 "connection, got error: \(result.error ?? "nil")"
         )
         XCTAssertEqual(result.hash, "headless-multisigner-hash")
@@ -507,16 +548,20 @@ final class OZConnectToContractTests: XCTestCase {
             credentialManager.updateLastUsedCalls.isEmpty,
             "the real multi-signer pipeline must never read connected.credentialId; " +
                 "updateLastUsed is its only consumer and must stay uninvoked for a " +
-                "sentinel-credential connection"
+                "headless connection"
+        )
+        XCTAssertNil(
+            kit.currentConnectedState?.credentialId,
+            "the connection must remain headless throughout the submission"
         )
         XCTAssertEqual(
-            kit.currentConnectedState?.credentialId,
-            OZConstants.headlessCredentialIdSentinel,
+            kit.currentConnectedState?.isHeadless,
+            true,
             "the connection must remain headless throughout the submission"
         )
     }
 
-    // MARK: - Hardening: passkey connect cannot adopt the headless sentinel
+    // MARK: - Hardening: passkey connect cannot adopt the empty credential id
 
     func test_connectWithCredentials_emptyCredentialId_throwsValidation() async throws {
         let h = try makeHarness()
@@ -541,8 +586,8 @@ final class OZConnectToContractTests: XCTestCase {
 
         // A pure-padding credential id is neither empty nor whitespace, so it
         // clears the blank check, but Base64URL padding stripping collapses it to
-        // the empty headless sentinel. It must be rejected so a passkey connect
-        // can never adopt the sentinel and trip the headless guard.
+        // the empty string. An empty credential id is not a valid WebAuthn
+        // credential and must be rejected.
         do {
             _ = try await h.walletOps.connectWallet(
                 options: OZConnectWalletOptions(credentialId: "==")

--- a/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZConnectToContractTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZConnectToContractTests.swift
@@ -1,0 +1,561 @@
+//
+//  OZConnectToContractTests.swift
+//  stellarsdkUnitTests
+//
+//  Copyright (c) 2026 Soneso. All rights reserved.
+//
+//  Hermetic tests for the headless ``OZWalletOperations/connectToContract(contractId:)``
+//  entry point and the matching headless guard on the single-passkey
+//  ``OZTransactionOperations/submit(hostFunction:auth:forceMethod:resolveContextRuleIds:)``
+//  path. Each case scripts the ``MockSorobanServerScript`` before invoking the
+//  production code so the on-chain existence check runs end-to-end without live
+//  RPC traffic.
+//
+
+import XCTest
+@testable import stellarsdk
+
+final class OZConnectToContractTests: XCTestCase {
+
+    // MARK: - Constants
+
+    private let contractA =
+        "CDCYWK73YTYFJZZSJ5V7EDFNHYBG4QN3VUNG2IGD27KJDDPNCZKBCBXK"
+    private let contractB =
+        "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
+
+    // MARK: - State
+
+    private var script: MockSorobanServerScript!
+
+    override func setUp() {
+        super.setUp()
+        script = MockSorobanServerScript()
+        MockSorobanServer.activate(script: script)
+    }
+
+    override func tearDown() {
+        MockSorobanServer.deactivate()
+        script = nil
+        MockURLProtocol.reset()
+        super.tearDown()
+    }
+
+    // MARK: - Harness
+
+    /// Captures the wiring a single test needs: the kit, the wallet-operations
+    /// instance under test, the recording credential manager, and the backing
+    /// in-memory storage adapter.
+    private struct Harness {
+        let kit: MockOZSmartAccountKit
+        let walletOps: OZWalletOperations
+        let credentialManager: MockCredentialManager
+        let storage: OZInMemoryStorageAdapter
+    }
+
+    /// Builds a kit wired to the scripted mock Soroban server. The credential
+    /// manager is the recording ``MockCredentialManager`` so tests can assert it
+    /// was never consulted; the storage adapter is shared with the kit so a
+    /// test can seed or read sessions through the same instance the production
+    /// code writes to.
+    private func makeHarness(
+        webauthnProvider: WebAuthnProvider? = nil
+    ) throws -> Harness {
+        let storage = OZInMemoryStorageAdapter()
+        let config = try OZSmartAccountConfig(
+            rpcUrl: "https://mock-rpc.invalid/rpc",
+            networkPassphrase: Network.testnet.passphrase,
+            accountWasmHash: "a" + String(repeating: "0", count: 63),
+            webauthnVerifierAddress: contractA,
+            webauthnProvider: webauthnProvider,
+            storage: storage
+        )
+        let credentialManager = MockCredentialManager(storage: storage)
+        let kit = MockOZSmartAccountKit(
+            config: config,
+            sorobanServer: MockSorobanServer.makeMockedSorobanServer(),
+            credentialManager: credentialManager
+        )
+        return Harness(
+            kit: kit,
+            walletOps: OZWalletOperations(kit: kit),
+            credentialManager: credentialManager,
+            storage: storage
+        )
+    }
+
+    /// Deterministic deployer keypair derived from the seed so the scripted
+    /// `getAccount` response can be keyed on the same account id.
+    private func deterministicDeployer(seed: UInt8) throws -> KeyPair {
+        let stellarSeed = try Seed(bytes: [UInt8](Data(repeating: seed, count: 32)))
+        return KeyPair(seed: stellarSeed)
+    }
+
+    /// A non-expired session bound to an arbitrary passkey credential and
+    /// contract, used to prove a headless connect clears pre-existing state.
+    private func nonExpiredSession(
+        credentialId: String,
+        contractId: String
+    ) -> OZStoredSession {
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        return OZStoredSession(
+            credentialId: credentialId,
+            contractId: contractId,
+            connectedAt: now,
+            expiresAt: now + OZConstants.defaultSessionExpiryMs
+        )
+    }
+
+    // MARK: - 1. Connected state
+
+    func test_connectToContract_existingContract_setsConnectedStateToContractId() async throws {
+        let h = try makeHarness()
+        try script.setGetContractDataResponse(contractId: contractA)
+
+        let result = try await h.walletOps.connectToContract(contractId: contractA)
+
+        XCTAssertEqual(result.contractId, contractA)
+        XCTAssertEqual(h.kit.currentConnectedState?.contractId, contractA)
+        XCTAssertEqual(h.kit.setConnectedStateInvocations.last?.contractId, contractA)
+        XCTAssertEqual(
+            h.kit.setConnectedStateInvocations.last?.credentialId,
+            "",
+            "headless connect must record the empty credential sentinel"
+        )
+        XCTAssertEqual(
+            h.kit.currentConnectedState?.credentialId,
+            OZConstants.headlessCredentialIdSentinel
+        )
+    }
+
+    // MARK: - 2. On-chain existence check
+
+    func test_connectToContract_verifiesContractExistsOnChain() async throws {
+        let h = try makeHarness()
+        // Drive an empty getLedgerEntries payload through the harness seam so
+        // getContractData surfaces .failure(.requestFailed); this proves the
+        // existence check actually ran rather than being skipped.
+        script.setEmptyGetLedgerEntriesResponse()
+
+        do {
+            _ = try await h.walletOps.connectToContract(contractId: contractA)
+            XCTFail("expected SmartAccountWalletException.NotFound")
+        } catch let error as SmartAccountWalletException.NotFound {
+            XCTAssertTrue(
+                error.message.contains(contractA),
+                "not-found error must identify the supplied contract id"
+            )
+        }
+
+        XCTAssertTrue(
+            h.kit.setConnectedStateInvocations.isEmpty,
+            "connected state must not be mutated when the existence check fails"
+        )
+        XCTAssertEqual(
+            script.getLedgerEntriesCallCount,
+            1,
+            "the existence check must have issued exactly one ledger-entry probe"
+        )
+    }
+
+    // MARK: - 3. Dedicated headless event
+
+    func test_connectToContract_emitsHeadlessEvent() async throws {
+        let h = try makeHarness()
+        try script.setGetContractDataResponse(contractId: contractA)
+
+        let headlessRecorder = EventRecorder()
+        let walletConnectedRecorder = EventRecorder()
+        h.kit.events.on(.walletConnectedHeadless) { event in
+            headlessRecorder.append(event)
+        }
+        h.kit.events.on(.walletConnected) { event in
+            walletConnectedRecorder.append(event)
+        }
+
+        _ = try await h.walletOps.connectToContract(contractId: contractA)
+
+        let headlessEvents = headlessRecorder.snapshot()
+        XCTAssertEqual(headlessEvents.count, 1)
+        guard case .walletConnectedHeadless(let emittedContractId)? = headlessEvents.first else {
+            return XCTFail("expected a walletConnectedHeadless event")
+        }
+        XCTAssertEqual(emittedContractId, contractA)
+        XCTAssertEqual(
+            walletConnectedRecorder.snapshot().count,
+            0,
+            "headless connect must not leak an empty credential onto walletConnected"
+        )
+    }
+
+    // MARK: - 4. No session saved
+
+    func test_connectToContract_doesNotSaveSession() async throws {
+        let h = try makeHarness()
+        try script.setGetContractDataResponse(contractId: contractA)
+
+        _ = try await h.walletOps.connectToContract(contractId: contractA)
+
+        let session = try await h.storage.getSession()
+        XCTAssertNil(session, "headless connect must not persist a session")
+    }
+
+    // MARK: - 5. Pre-existing session cleared
+
+    func test_connectToContract_clearsExistingSession() async throws {
+        let h = try makeHarness()
+        try await h.storage.saveSession(
+            nonExpiredSession(credentialId: "stale-passkey-cred", contractId: contractB)
+        )
+        // Sanity: the session is present before the headless connect.
+        let seeded = try await h.storage.getSession()
+        XCTAssertNotNil(seeded)
+
+        try script.setGetContractDataResponse(contractId: contractA)
+        _ = try await h.walletOps.connectToContract(contractId: contractA)
+
+        let session = try await h.storage.getSession()
+        XCTAssertNil(
+            session,
+            "a pre-existing passkey session must be cleared so a later silent " +
+                "restore cannot resurrect state contradicting the headless connection"
+        )
+    }
+
+    // MARK: - 6. Credential manager untouched
+
+    func test_connectToContract_doesNotTouchCredentialManager() async throws {
+        let h = try makeHarness()
+        try script.setGetContractDataResponse(contractId: contractA)
+
+        _ = try await h.walletOps.connectToContract(contractId: contractA)
+
+        XCTAssertTrue(h.credentialManager.createPendingCalls.isEmpty)
+        XCTAssertTrue(h.credentialManager.setPrimaryCalls.isEmpty)
+        XCTAssertTrue(h.credentialManager.updateLastUsedCalls.isEmpty)
+        XCTAssertTrue(h.credentialManager.deleteCredentialCalls.isEmpty)
+        XCTAssertTrue(h.credentialManager.markDeploymentFailedCalls.isEmpty)
+    }
+
+    // MARK: - 7. Invalid contract id
+
+    func test_connectToContract_invalidContractId_throwsValidation() async throws {
+        let h = try makeHarness()
+
+        do {
+            _ = try await h.walletOps.connectToContract(contractId: "not-a-contract")
+            XCTFail("expected SmartAccountValidationException.InvalidAddress")
+        } catch is SmartAccountValidationException.InvalidAddress {
+            // expected
+        }
+
+        XCTAssertTrue(
+            h.kit.setConnectedStateInvocations.isEmpty,
+            "invalid input must not mutate connected state"
+        )
+        XCTAssertEqual(
+            script.getLedgerEntriesCallCount,
+            0,
+            "address validation must fail before any contract-data RPC is issued"
+        )
+    }
+
+    // MARK: - 8. No WebAuthn provider required
+
+    func test_connectToContract_worksWithoutWebAuthnProvider() async throws {
+        let h = try makeHarness(webauthnProvider: nil)
+        XCTAssertNil(h.kit.config.webauthnProvider)
+        try script.setGetContractDataResponse(contractId: contractA)
+
+        let result = try await h.walletOps.connectToContract(contractId: contractA)
+
+        XCTAssertEqual(result.contractId, contractA)
+        XCTAssertTrue(h.kit.isConnected)
+    }
+
+    // MARK: - 9. Headless guard on the single-passkey path
+
+    func test_connectToContract_thenSinglePasskeySubmit_throwsHeadlessGuard() async throws {
+        let h = try makeHarness()
+        try script.setGetContractDataResponse(contractId: contractA)
+        _ = try await h.walletOps.connectToContract(contractId: contractA)
+
+        // Baseline after the headless connect: exactly one ledger-entry probe
+        // from the existence check, no simulate calls. Each guarded call below
+        // must leave both unchanged, proving the guard fired before any
+        // network traffic, deployer fetch, simulation, decode, or WebAuthn.
+        let ledgerEntriesBaseline = script.getLedgerEntriesCallCount
+        XCTAssertEqual(ledgerEntriesBaseline, 1)
+        XCTAssertEqual(script.simulateCallCount, 0)
+
+        /// Asserts the supplied single-passkey call throws the headless guard
+        /// error before issuing any network traffic.
+        func assertGuardFires(
+            _ label: String,
+            _ block: () async throws -> Void,
+            line: UInt = #line
+        ) async {
+            do {
+                try await block()
+                XCTFail("\(label): expected the headless guard to throw", line: line)
+            } catch let error as SmartAccountValidationException.InvalidInput {
+                XCTAssertTrue(
+                    error.message.contains("selectedSigners"),
+                    "\(label): guard error must point at selectedSigners",
+                    line: line
+                )
+                XCTAssertTrue(
+                    error.message.contains("headlessly"),
+                    "\(label): guard error must explain the headless cause",
+                    line: line
+                )
+            } catch {
+                XCTFail("\(label): expected InvalidInput, got \(error)", line: line)
+            }
+            XCTAssertEqual(
+                script.getLedgerEntriesCallCount,
+                ledgerEntriesBaseline,
+                "\(label): no ledger-entry RPC may run before the guard",
+                line: line
+            )
+            XCTAssertEqual(
+                script.simulateCallCount,
+                0,
+                "\(label): no simulation may run before the guard",
+                line: line
+            )
+            XCTAssertTrue(
+                h.credentialManager.updateLastUsedCalls.isEmpty,
+                "\(label): updateLastUsed must not be reached before the guard",
+                line: line
+            )
+        }
+
+        let hostFn = HostFunctionXDR.invokeContract(
+            InvokeContractArgsXDR(
+                contractAddress: try SCAddressXDR(contractId: contractB),
+                functionName: "noop",
+                args: []
+            )
+        )
+
+        await assertGuardFires("submit") {
+            _ = try await h.kit.transactionOperations.submit(hostFunction: hostFn, auth: [])
+        }
+        await assertGuardFires("contractCall") {
+            _ = try await h.kit.transactionOperations.contractCall(
+                target: contractB,
+                targetFn: "noop"
+            )
+        }
+        await assertGuardFires("executeAndSubmit") {
+            _ = try await h.kit.transactionOperations.executeAndSubmit(
+                target: contractB,
+                targetFn: "noop"
+            )
+        }
+        await assertGuardFires("removeSigner-default-empty-selectedSigners") {
+            _ = try await h.kit.signerManager.removeSigner(
+                contextRuleId: 0,
+                signerId: 0
+            )
+        }
+    }
+
+    // MARK: - 10. Routing: a non-empty selectedSigners list bypasses the guard
+
+    /// Routing only. Installs a recording multi-signer manager to observe that a
+    /// non-empty `selectedSigners` list on a sibling-manager call routes to
+    /// ``OZSmartAccountKitProtocol/multiSignerManager`` and the headless guard
+    /// does not fire. The override short-circuits before any real signing runs,
+    /// so this test proves routing, not credential-safety; the real-pipeline
+    /// credential boundary is proven in
+    /// ``test_connectToContract_thenRealMultiSignerPipeline_neverReadsConnectedCredential()``.
+    func test_connectToContract_nonEmptySelectedSigners_routesToMultiSignerPipeline() async throws {
+        let h = try makeHarness()
+        try script.setGetContractDataResponse(contractId: contractA)
+        _ = try await h.walletOps.connectToContract(contractId: contractA)
+
+        let recordingSubmitter = MockOZMultiSignerManager(kit: h.kit)
+        h.kit.multiSignerManagerOverride = recordingSubmitter
+
+        let ed25519Signer = OZSelectedSigner.ed25519(
+            verifierAddress: contractB,
+            publicKey: Data(repeating: 0x09, count: 32)
+        )
+
+        // The same entry point that trips the headless guard with an empty
+        // selectedSigners list (test 9) must instead reach the multi-signer
+        // pipeline when a non-empty list is supplied. If routing were broken and
+        // the call fell into the guarded single-passkey path, the guard would
+        // throw here rather than returning a result.
+        let result = try await h.kit.signerManager.removeSigner(
+            contextRuleId: 0,
+            signerId: 0,
+            selectedSigners: [ed25519Signer]
+        )
+
+        XCTAssertTrue(result.success)
+        XCTAssertEqual(
+            recordingSubmitter.invocations.count,
+            1,
+            "a non-empty selectedSigners list must route through the multi-signer pipeline"
+        )
+        XCTAssertEqual(recordingSubmitter.invocations[0].selectedSigners, [ed25519Signer])
+        XCTAssertEqual(
+            script.simulateCallCount,
+            0,
+            "sanity: the recording submitter short-circuits before the real " +
+                "signing pipeline, so no simulate RPC is issued in this routing check"
+        )
+    }
+
+    // MARK: - 11. Real multi-signer pipeline never reads the connected credential
+
+    /// Credential boundary, proven against the REAL ``OZMultiSignerManager`` with
+    /// no recording override. After a headless connect records the empty
+    /// credential sentinel, an Ed25519-signed ``multiSignerContractCall`` drives
+    /// the production signing pipeline end-to-end to submission against the
+    /// scripted Soroban server. The pipeline reads only
+    /// ``ConnectedState/contractId`` and never ``ConnectedState/credentialId``,
+    /// so a sentinel-credential connection submits cleanly and `updateLastUsed`
+    /// (the sole consumer of the connected credential) is never invoked. This is
+    /// the practical proof of the boundary that the mocked routing check in
+    /// test 10 cannot give.
+    func test_connectToContract_thenRealMultiSignerPipeline_neverReadsConnectedCredential() async throws {
+        let storage = OZInMemoryStorageAdapter()
+        let deployer = try deterministicDeployer(seed: 0x5A)
+        let config = try OZSmartAccountConfig(
+            rpcUrl: "https://mock-rpc.invalid/rpc",
+            networkPassphrase: Network.testnet.passphrase,
+            accountWasmHash: "a" + String(repeating: "0", count: 63),
+            webauthnVerifierAddress: contractA,
+            deployerKeypair: deployer,
+            webauthnProvider: nil,
+            storage: storage
+        )
+        let credentialManager = MockCredentialManager(storage: storage)
+        let kit = MockOZSmartAccountKit(
+            config: config,
+            sorobanServer: MockSorobanServer.makeMockedSorobanServer(),
+            credentialManager: credentialManager
+        )
+        kit.configuredDeployer = deployer
+        let walletOps = OZWalletOperations(kit: kit)
+
+        // 1) Headless connect against contractA. This consumes the contract-data
+        //    existence probe (the single getLedgerEntries result).
+        try script.setGetContractDataResponse(contractId: contractA)
+        _ = try await walletOps.connectToContract(contractId: contractA)
+        XCTAssertEqual(
+            kit.currentConnectedState?.credentialId,
+            OZConstants.headlessCredentialIdSentinel,
+            "precondition: the connection must hold the empty credential sentinel"
+        )
+
+        // 2) Register an in-memory Ed25519 external signer whose verifier is the
+        //    connected smart-account contract.
+        let extMgr = OZExternalSignerManager(networkPassphrase: Network.testnet.passphrase)
+        kit.externalSignersOverride = extMgr
+        let ed25519PublicKey = try await extMgr.addEd25519FromRawKey(
+            secretKeyBytes: Data(0x00 ..< 0x20),
+            verifierAddress: contractA
+        )
+
+        // 3) Script the full submission pipeline. setGetAccountResponse replaces
+        //    the contract-data getLedgerEntries result consumed by the connect
+        //    above, so the deployer-account fetch now succeeds.
+        script.setGetAccountResponse(accountId: deployer.accountId, sequence: 17)
+        let authEntry = try OZPipelineFixtures.addressCredentialsAuthEntry(
+            contractAddress: contractA,
+            targetContract: contractB,
+            targetFn: "noop"
+        )
+        script.enqueueSimulate(authEntries: [authEntry])
+        script.setGetLatestLedger(sequence: 1000)
+        script.enqueueSimulate(authEntries: [], minResourceFee: 200)
+        script.setSendSuccess(
+            status: SendTransactionResponse.STATUS_PENDING,
+            hash: "headless-multisigner-hash"
+        )
+        script.enqueueGetTransactionResponse(
+            status: GetTransactionResponse.STATUS_SUCCESS,
+            ledger: 1002
+        )
+
+        // 4) Drive the REAL multi-signer manager to submission.
+        let result = try await kit.multiSignerManager.multiSignerContractCall(
+            target: contractB,
+            targetFn: "noop",
+            selectedSigners: [
+                .ed25519(verifierAddress: contractA, publicKey: ed25519PublicKey)
+            ]
+        )
+
+        XCTAssertTrue(
+            result.success,
+            "the multi-signer pipeline must submit cleanly on a sentinel-credential " +
+                "connection, got error: \(result.error ?? "nil")"
+        )
+        XCTAssertEqual(result.hash, "headless-multisigner-hash")
+        XCTAssertEqual(
+            script.sendCallCount,
+            1,
+            "the real pipeline must reach submission exactly once"
+        )
+        XCTAssertTrue(
+            credentialManager.updateLastUsedCalls.isEmpty,
+            "the real multi-signer pipeline must never read connected.credentialId; " +
+                "updateLastUsed is its only consumer and must stay uninvoked for a " +
+                "sentinel-credential connection"
+        )
+        XCTAssertEqual(
+            kit.currentConnectedState?.credentialId,
+            OZConstants.headlessCredentialIdSentinel,
+            "the connection must remain headless throughout the submission"
+        )
+    }
+
+    // MARK: - Hardening: passkey connect cannot adopt the headless sentinel
+
+    func test_connectWithCredentials_emptyCredentialId_throwsValidation() async throws {
+        let h = try makeHarness()
+
+        do {
+            _ = try await h.walletOps.connectWallet(
+                options: OZConnectWalletOptions(credentialId: "")
+            )
+            XCTFail("expected SmartAccountValidationException.InvalidInput")
+        } catch let error as SmartAccountValidationException.InvalidInput {
+            XCTAssertTrue(error.message.contains("credentialId"))
+        }
+
+        XCTAssertTrue(
+            h.kit.setConnectedStateInvocations.isEmpty,
+            "a blank credential id must be rejected before any connected-state write"
+        )
+    }
+
+    func test_connectWithCredentials_purePaddingCredentialId_throwsValidation() async throws {
+        let h = try makeHarness()
+
+        // A pure-padding credential id is neither empty nor whitespace, so it
+        // clears the blank check, but Base64URL padding stripping collapses it to
+        // the empty headless sentinel. It must be rejected so a passkey connect
+        // can never adopt the sentinel and trip the headless guard.
+        do {
+            _ = try await h.walletOps.connectWallet(
+                options: OZConnectWalletOptions(credentialId: "==")
+            )
+            XCTFail("expected SmartAccountValidationException.InvalidInput")
+        } catch let error as SmartAccountValidationException.InvalidInput {
+            XCTAssertTrue(error.message.contains("credentialId"))
+        }
+
+        XCTAssertTrue(
+            h.kit.setConnectedStateInvocations.isEmpty,
+            "a credential id that normalizes to empty must be rejected before any " +
+                "connected-state write"
+        )
+    }
+}

--- a/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZConstantsTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZConstantsTests.swift
@@ -26,12 +26,12 @@ final class OZConstantsTests: XCTestCase {
         XCTAssertEqual(OZConstants.friendbotReserveXlm, 5)
     }
 
-    func test_FRIENDBOT_VISIBILITY_POLL_INTERVAL_MS_equals_1500() {
-        XCTAssertEqual(OZConstants.friendbotVisibilityPollIntervalMs, 1500)
+    func test_RPC_VISIBILITY_POLL_INTERVAL_MS_equals_1500() {
+        XCTAssertEqual(OZConstants.rpcVisibilityPollIntervalMs, 1500)
     }
 
-    func test_FRIENDBOT_VISIBILITY_TIMEOUT_SECONDS_equals_45() {
-        XCTAssertEqual(OZConstants.friendbotVisibilityTimeoutSeconds, 45)
+    func test_RPC_VISIBILITY_TIMEOUT_SECONDS_equals_45() {
+        XCTAssertEqual(OZConstants.rpcVisibilityTimeoutSeconds, 45)
     }
 
     func test_DEFAULT_TIMEOUT_SECONDS_equals_30() {
@@ -68,8 +68,8 @@ final class OZConstantsTests: XCTestCase {
             OZConstants.defaultIndexerTimeoutMs,
             OZConstants.defaultRelayerTimeoutMs,
             OZConstants.friendbotReserveXlm,
-            OZConstants.friendbotVisibilityPollIntervalMs,
-            OZConstants.friendbotVisibilityTimeoutSeconds,
+            OZConstants.rpcVisibilityPollIntervalMs,
+            OZConstants.rpcVisibilityTimeoutSeconds,
             OZConstants.defaultTimeoutSeconds,
             OZConstants.maxSigners,
             OZConstants.maxPolicies,

--- a/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZConstantsTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZConstantsTests.swift
@@ -26,6 +26,14 @@ final class OZConstantsTests: XCTestCase {
         XCTAssertEqual(OZConstants.friendbotReserveXlm, 5)
     }
 
+    func test_FRIENDBOT_VISIBILITY_POLL_INTERVAL_MS_equals_1500() {
+        XCTAssertEqual(OZConstants.friendbotVisibilityPollIntervalMs, 1500)
+    }
+
+    func test_FRIENDBOT_VISIBILITY_TIMEOUT_SECONDS_equals_45() {
+        XCTAssertEqual(OZConstants.friendbotVisibilityTimeoutSeconds, 45)
+    }
+
     func test_DEFAULT_TIMEOUT_SECONDS_equals_30() {
         XCTAssertEqual(OZConstants.defaultTimeoutSeconds, 30)
     }
@@ -50,21 +58,31 @@ final class OZConstantsTests: XCTestCase {
         XCTAssertEqual(OZConstants.clientName, "ios-stellar-sdk")
     }
 
-    func test_OZConstants_exposes_exactly_10_public_constants() {
-        // Each named constant must be reachable; reading every one and ensuring the
-        // collection size is exactly 10 catches accidental additions or removals.
-        let values: [Any] = [
+    func test_OZConstants_publicSurface_isReachable() {
+        // Referencing every public constant in one place makes a rename or
+        // removal fail to compile here. This is a hand-maintained inventory, not
+        // an automatic guard: adding a constant without listing it does NOT fail
+        // this test, so the list must be updated alongside the public surface.
+        _ = [
             OZConstants.defaultSessionExpiryMs,
             OZConstants.defaultIndexerTimeoutMs,
             OZConstants.defaultRelayerTimeoutMs,
             OZConstants.friendbotReserveXlm,
+            OZConstants.friendbotVisibilityPollIntervalMs,
+            OZConstants.friendbotVisibilityTimeoutSeconds,
             OZConstants.defaultTimeoutSeconds,
             OZConstants.maxSigners,
             OZConstants.maxPolicies,
             OZConstants.clientNameHeader,
             OZConstants.clientVersionHeader,
             OZConstants.clientName,
-        ]
-        XCTAssertEqual(values.count, 10)
+            OZConstants.maxIndexerResponseBytes,
+            OZConstants.maxRelayerResponseBytes,
+        ] as [Any]
+
+        // The byte-size limits have no dedicated value test above, so pin them
+        // directly rather than leaving the assertion tautological.
+        XCTAssertEqual(OZConstants.maxIndexerResponseBytes, 1 * 1024 * 1024)
+        XCTAssertEqual(OZConstants.maxRelayerResponseBytes, 256 * 1024)
     }
 }

--- a/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZCredentialManagerTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZCredentialManagerTests.swift
@@ -1743,7 +1743,7 @@ private final class _CredentialManagerTestKit: OZSmartAccountKitProtocol, @unche
         throw SmartAccountWalletException.notConnected(details: "Test kit is always disconnected")
     }
 
-    func setConnectedState(credentialId: String, contractId: String) {}
+    func setConnectedState(credentialId: String?, contractId: String) {}
 }
 
 // MARK: - _TypedThrowingStorage

--- a/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZTransactionOperationsPipelineTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZTransactionOperationsPipelineTests.swift
@@ -855,6 +855,161 @@ final class OZTransactionOperationsPipelineTests: XCTestCase {
     }
 
     // ========================================================================
+    // waitForAccountVisibleToRpc - Friendbot propagation poll
+    // ========================================================================
+
+    func test_waitForAccountVisibleToRpc_pollsUntilVisible_thenProceeds() async throws {
+        let h = try await buildPipelineHarness()
+        let temp = try KeyPair.generateRandomKeyPair()
+
+        // The first two polls report the account is not yet on the ledger the
+        // RPC has applied (empty getLedgerEntries -> "could not find account");
+        // the third poll sees it.
+        script.enqueueGetLedgerEntriesResponse(
+            OZPipelineFixtures.emptyGetLedgerEntriesResponse()
+        )
+        script.enqueueGetLedgerEntriesResponse(
+            OZPipelineFixtures.emptyGetLedgerEntriesResponse()
+        )
+        script.setGetAccountResponse(accountId: temp.accountId, sequence: 7)
+
+        let start = Date()
+        let resolved = try await h.txOps.waitForAccountVisibleToRpc(
+            accountId: temp.accountId,
+            pollIntervalMs: 40,
+            timeoutSeconds: 5
+        )
+        let elapsed = Date().timeIntervalSince(start)
+
+        // The helper returns the now-visible account so the caller can reuse it
+        // without a second RPC round-trip.
+        XCTAssertEqual(
+            resolved.keyPair.accountId, temp.accountId,
+            "the resolved account must be the one that became visible"
+        )
+        XCTAssertEqual(
+            resolved.sequenceNumber, 7,
+            "the resolved account must carry the sequence number the RPC reported"
+        )
+        XCTAssertEqual(
+            script.getLedgerEntriesCallCount, 3,
+            "expected two not-found polls followed by one visible poll"
+        )
+        // Two inter-poll sleeps of 40 ms must have elapsed before the account
+        // was observed, proving the helper waits between attempts rather than
+        // spinning.
+        XCTAssertGreaterThanOrEqual(
+            elapsed, 0.07,
+            "the poll must wait between attempts rather than busy-looping"
+        )
+    }
+
+    func test_waitForAccountVisibleToRpc_neverVisible_throwsClearTimeout() async throws {
+        let h = try await buildPipelineHarness()
+        let temp = try KeyPair.generateRandomKeyPair()
+
+        // Every poll reports the account is missing.
+        script.setEmptyGetLedgerEntriesResponse()
+
+        do {
+            _ = try await h.txOps.waitForAccountVisibleToRpc(
+                accountId: temp.accountId,
+                pollIntervalMs: 30,
+                timeoutSeconds: 0.2
+            )
+            XCTFail("expected SmartAccountTransactionException.Timeout")
+        } catch let error as SmartAccountTransactionException.Timeout {
+            XCTAssertTrue(
+                error.message.contains(temp.accountId),
+                "timeout message should name the funding account: \(error.message)"
+            )
+            XCTAssertTrue(
+                error.message.contains("not visible to the Soroban RPC"),
+                "timeout message should describe the visibility failure: \(error.message)"
+            )
+            XCTAssertTrue(
+                error.message.contains("Retry shortly"),
+                "timeout message should advise a retry: \(error.message)"
+            )
+            // A pure not-found timeout has no underlying transient failure: the
+            // account simply never appeared. Pinning the absence of a cause and
+            // of the transient-error suffix guards against a regression that
+            // misclassifies the expected not-found signal as a transient RPC
+            // error.
+            XCTAssertNil(
+                error.cause,
+                "a not-found timeout must carry no underlying cause: \(String(describing: error.cause))"
+            )
+            XCTAssertFalse(
+                error.message.contains("Last RPC error:"),
+                "a not-found timeout must not append a transient RPC error: \(error.message)"
+            )
+        }
+        XCTAssertGreaterThanOrEqual(
+            script.getLedgerEntriesCallCount, 1,
+            "the helper must poll at least once before timing out"
+        )
+    }
+
+    func test_waitForAccountVisibleToRpc_transientRpcError_surfacedAsTimeoutCause() async throws {
+        let h = try await buildPipelineHarness()
+        let temp = try KeyPair.generateRandomKeyPair()
+
+        // No scripted getLedgerEntries response: the mock answers every
+        // getAccount with a JSON-RPC error envelope, exercising the
+        // transient-error retry path (distinct from "account not found yet").
+        do {
+            _ = try await h.txOps.waitForAccountVisibleToRpc(
+                accountId: temp.accountId,
+                pollIntervalMs: 30,
+                timeoutSeconds: 0.2
+            )
+            XCTFail("expected SmartAccountTransactionException.Timeout")
+        } catch let error as SmartAccountTransactionException.Timeout {
+            XCTAssertTrue(
+                error.message.contains("not visible to the Soroban RPC"),
+                "timeout message should describe the visibility failure: \(error.message)"
+            )
+            XCTAssertTrue(
+                error.message.contains("Last RPC error:"),
+                "a transient RPC error must be surfaced as the timeout cause: \(error.message)"
+            )
+            XCTAssertNotNil(
+                error.cause,
+                "a transient-error timeout must retain the transient RPC error as its cause"
+            )
+        }
+    }
+
+    func test_waitForAccountVisibleToRpc_cancellation_throwsCancellationError() async throws {
+        let h = try await buildPipelineHarness()
+        let temp = try KeyPair.generateRandomKeyPair()
+
+        // Never visible, with a long poll interval so the task parks in
+        // Task.sleep while we cancel it.
+        script.setEmptyGetLedgerEntriesResponse()
+
+        let task = Task {
+            try await h.txOps.waitForAccountVisibleToRpc(
+                accountId: temp.accountId,
+                pollIntervalMs: 1000,
+                timeoutSeconds: 30
+            )
+        }
+        // Let the first poll run and the helper enter its inter-poll sleep,
+        // then cancel cooperatively.
+        try await Task.sleep(nanoseconds: 100_000_000)
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("expected CancellationError")
+        } catch is CancellationError {
+            // expected: Task.sleep / checkCancellation honour cancellation
+        }
+    }
+
+    // ========================================================================
     // Relayer-vs-RPC
     // ========================================================================
 

--- a/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZTransactionOperationsPipelineTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZTransactionOperationsPipelineTests.swift
@@ -1010,6 +1010,196 @@ final class OZTransactionOperationsPipelineTests: XCTestCase {
     }
 
     // ========================================================================
+    // waitForContractVisibleToRpc - deployed-contract propagation poll
+    // ========================================================================
+
+    func test_waitForContractVisibleToRpc_pollsUntilVisible_thenProceeds() async throws {
+        let h = try await buildPipelineHarness()
+
+        // The first two polls report the contract's instance entry is not yet
+        // on the ledger the RPC has applied (empty getLedgerEntries); the third
+        // poll observes the persistent ContractData instance entry.
+        script.enqueueGetLedgerEntriesResponse(
+            OZPipelineFixtures.emptyGetLedgerEntriesResponse()
+        )
+        script.enqueueGetLedgerEntriesResponse(
+            OZPipelineFixtures.emptyGetLedgerEntriesResponse()
+        )
+        let visible = try XCTUnwrap(
+            try OZPipelineFixtures.validGetContractDataResponse(contractId: contractB)
+        )
+        script.enqueueGetLedgerEntriesResponse(visible)
+
+        let start = Date()
+        try await h.txOps.waitForContractVisibleToRpc(
+            contractId: contractB,
+            pollIntervalMs: 40,
+            timeoutSeconds: 5
+        )
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertEqual(
+            script.getLedgerEntriesCallCount, 3,
+            "expected two not-visible polls followed by one visible poll"
+        )
+        // Two inter-poll sleeps of 40 ms must have elapsed before the contract
+        // was observed, proving the helper waits between attempts rather than
+        // spinning.
+        XCTAssertGreaterThanOrEqual(
+            elapsed, 0.07,
+            "the poll must wait between attempts rather than busy-looping"
+        )
+    }
+
+    func test_waitForContractVisibleToRpc_visibleOnFirstPoll_returnsWithoutSleeping() async throws {
+        let h = try await buildPipelineHarness()
+
+        // The contract is visible on the very first probe. With a 2 s poll
+        // interval, a helper that slept after a successful poll would block for
+        // ~2 s; the helper must return immediately because it returns before
+        // ever reaching the inter-poll sleep. This pins "did not sleep after
+        // success" deterministically rather than via a fragile timing window.
+        let visible = try XCTUnwrap(
+            try OZPipelineFixtures.validGetContractDataResponse(contractId: contractB)
+        )
+        script.enqueueGetLedgerEntriesResponse(visible)
+
+        let start = Date()
+        try await h.txOps.waitForContractVisibleToRpc(
+            contractId: contractB,
+            pollIntervalMs: 2000,
+            timeoutSeconds: 30
+        )
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertEqual(
+            script.getLedgerEntriesCallCount, 1,
+            "a contract visible on the first probe must be observed in one poll"
+        )
+        XCTAssertLessThan(
+            elapsed, 1.0,
+            "the helper must not sleep after observing the contract as visible"
+        )
+    }
+
+    func test_waitForContractVisibleToRpc_neverVisible_throwsClearTimeout() async throws {
+        let h = try await buildPipelineHarness()
+
+        // Every poll reports the contract instance is missing.
+        script.setEmptyGetLedgerEntriesResponse()
+
+        do {
+            try await h.txOps.waitForContractVisibleToRpc(
+                contractId: contractB,
+                pollIntervalMs: 30,
+                timeoutSeconds: 0.2
+            )
+            XCTFail("expected SmartAccountTransactionException.Timeout")
+        } catch let error as SmartAccountTransactionException.Timeout {
+            XCTAssertTrue(
+                error.message.contains(contractB),
+                "timeout message should name the deployed contract: \(error.message)"
+            )
+            XCTAssertTrue(
+                error.message.contains("not visible to the Soroban RPC"),
+                "timeout message should describe the visibility failure: \(error.message)"
+            )
+            XCTAssertTrue(
+                error.message.contains("Retry shortly"),
+                "timeout message should advise a retry: \(error.message)"
+            )
+            // A pure not-visible timeout has no underlying transient failure:
+            // the contract simply never appeared. Pinning the absence of a cause
+            // and of the transient-error suffix guards against a regression that
+            // misclassifies the expected empty-entries signal as a transient
+            // RPC error.
+            XCTAssertNil(
+                error.cause,
+                "a not-visible timeout must carry no underlying cause: \(String(describing: error.cause))"
+            )
+            XCTAssertFalse(
+                error.message.contains("Last RPC error:"),
+                "a not-visible timeout must not append a transient RPC error: \(error.message)"
+            )
+        }
+        XCTAssertGreaterThanOrEqual(
+            script.getLedgerEntriesCallCount, 1,
+            "the helper must poll at least once before timing out"
+        )
+    }
+
+    func test_waitForContractVisibleToRpc_transientRpcError_surfacedAsTimeoutCause() async throws {
+        let h = try await buildPipelineHarness()
+
+        // No scripted getLedgerEntries response: the mock answers every probe
+        // with a JSON-RPC error envelope, exercising the transient-error retry
+        // path (distinct from the empty-entries "not visible yet" signal).
+        do {
+            try await h.txOps.waitForContractVisibleToRpc(
+                contractId: contractB,
+                pollIntervalMs: 30,
+                timeoutSeconds: 0.2
+            )
+            XCTFail("expected SmartAccountTransactionException.Timeout")
+        } catch let error as SmartAccountTransactionException.Timeout {
+            XCTAssertTrue(
+                error.message.contains("not visible to the Soroban RPC"),
+                "timeout message should describe the visibility failure: \(error.message)"
+            )
+            XCTAssertTrue(
+                error.message.contains("Last RPC error:"),
+                "a transient RPC error must be surfaced as the timeout cause: \(error.message)"
+            )
+            XCTAssertNotNil(
+                error.cause,
+                "a transient-error timeout must retain the transient RPC error as its cause"
+            )
+        }
+    }
+
+    func test_waitForContractVisibleToRpc_cancellation_throwsCancellationError() async throws {
+        let h = try await buildPipelineHarness()
+
+        // Never visible, with a long poll interval so the task parks in
+        // Task.sleep while we cancel it.
+        script.setEmptyGetLedgerEntriesResponse()
+
+        let contractId = contractB
+        let task = Task {
+            try await h.txOps.waitForContractVisibleToRpc(
+                contractId: contractId,
+                pollIntervalMs: 1000,
+                timeoutSeconds: 30
+            )
+        }
+        // Let the first poll run and the helper enter its inter-poll sleep,
+        // then cancel cooperatively.
+        try await Task.sleep(nanoseconds: 100_000_000)
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("expected CancellationError")
+        } catch is CancellationError {
+            // expected: cancellation must not be converted into a Timeout or
+            // recorded as a transient RPC error.
+        }
+    }
+
+    func test_contractInstanceLedgerKey_invalidContractId_throwsInvalidAddress() {
+        do {
+            _ = try OZTransactionOperations.contractInstanceLedgerKey(
+                contractId: "not-a-contract"
+            )
+            XCTFail("expected SmartAccountValidationException.InvalidAddress")
+        } catch is SmartAccountValidationException.InvalidAddress {
+            // expected: a malformed contract id cannot be encoded into a key
+        } catch {
+            XCTFail("expected InvalidAddress, got \(error)")
+        }
+    }
+
+    // ========================================================================
     // Relayer-vs-RPC
     // ========================================================================
 

--- a/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZTransactionOperationsTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZTransactionOperationsTests.swift
@@ -1178,6 +1178,56 @@ final class OZTransactionOperationsTests: XCTestCase {
     }
 
     // ========================================================================
+    // MARK: - isAccountNotVisibleError not-found classification
+    // ========================================================================
+
+    func test_isAccountNotVisibleError_notFoundSignal_returnsTrue() {
+        // The exact failure shape `getAccount(accountId:)` emits for an account
+        // whose ledger entry is absent. This must classify as not-yet-visible so
+        // the funding poll keeps retrying rather than aborting on a transient
+        // error. Pinning `true` here fails immediately if the detection were
+        // broken to always return false.
+        let error = SorobanRpcRequestError.requestFailed(
+            message: SorobanServer.accountNotFoundMessage
+        )
+        XCTAssertTrue(OZTransactionOperations.isAccountNotVisibleError(error))
+    }
+
+    func test_isAccountNotVisibleError_matchesGetAccountLiteral() {
+        // The shared constant carries the exact text `getAccount` returns for an
+        // absent account, so a not-found result is recognised whether a caller
+        // matches the constant or the raw message.
+        XCTAssertEqual(SorobanServer.accountNotFoundMessage, "could not find account")
+        let error = SorobanRpcRequestError.requestFailed(message: "could not find account")
+        XCTAssertTrue(OZTransactionOperations.isAccountNotVisibleError(error))
+    }
+
+    func test_isAccountNotVisibleError_otherRequestFailedMessage_returnsFalse() {
+        // A different `.requestFailed` message (for example the invalid-accountId
+        // path) is a genuine failure, not a not-yet-visible account, and must be
+        // treated as transient.
+        let error = SorobanRpcRequestError.requestFailed(message: "invalid accountId")
+        XCTAssertFalse(OZTransactionOperations.isAccountNotVisibleError(error))
+    }
+
+    func test_isAccountNotVisibleError_errorResponse_returnsFalse() {
+        // A JSON-RPC error envelope is a transport/protocol failure, never the
+        // expected not-found signal.
+        let error = SorobanRpcRequestError.errorResponse(
+            error: SorobanRpcError(code: -32603, message: "internal error")
+        )
+        XCTAssertFalse(OZTransactionOperations.isAccountNotVisibleError(error))
+    }
+
+    func test_isAccountNotVisibleError_parsingFailure_returnsFalse() {
+        let error = SorobanRpcRequestError.parsingResponseFailed(
+            message: "bad json",
+            responseData: Data()
+        )
+        XCTAssertFalse(OZTransactionOperations.isAccountNotVisibleError(error))
+    }
+
+    // ========================================================================
     // Helpers
     // ========================================================================
 

--- a/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZWalletOperationsTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZWalletOperationsTests.swift
@@ -1645,6 +1645,93 @@ final class OZWalletOperationsTests: XCTestCase {
         )
     }
 
+    func test_createWallet_autoFund_invokesContractVisibilityPoll() async throws {
+        let script = activatePipelineRpc()
+        defer { deactivatePipelineRpc() }
+
+        let provider = RecordingWebAuthnProvider()
+        let deployer = try pipelineDeployer()
+        let storage = OZInMemoryStorageAdapter()
+        let config = try pipelineConfig(provider: provider, deployer: deployer, storage: storage)
+        let kit = MockOZSmartAccountKit(
+            config: config,
+            sorobanServer: MockSorobanServer.makeMockedSorobanServer()
+        )
+        kit.configuredDeployer = deployer
+
+        let credentialIdBytes = try Data(base64URLEncoded: pipelineCredentialIdB64Url)
+        provider.enqueueRegister(registrationResult(credentialId: credentialIdBytes))
+        // createWallet derives the contract address from the registration
+        // credential id; recompute it to assert the visibility poll probed it.
+        let derivedContractId = try SmartAccountUtils.deriveContractAddress(
+            credentialId: credentialIdBytes,
+            deployerPublicKey: deployer.accountId,
+            networkPassphrase: Network.testnet.passphrase
+        )
+
+        // The deploy build fetches the deployer account and the contract
+        // visibility poll probes getLedgerEntries; the shared default returns a
+        // non-empty (deployer-account) entry, so the poll observes the contract
+        // as visible on its first probe and the flow proceeds to funding.
+        enqueueDeployerAccount(script, deployer: deployer)
+        script.enqueueSimulate(authEntries: [], minResourceFee: 50_000)
+        script.setSendSuccess(
+            status: SendTransactionResponse.STATUS_PENDING,
+            hash: "create-fund-hash"
+        )
+        script.setGetTransactionDefault(
+            payload: OZPipelineFixtures.validGetTransactionResponse(
+                status: GetTransactionResponse.STATUS_SUCCESS,
+                ledger: 7777
+            )
+        )
+
+        // Route friendbot to a 500 so funding throws immediately once it is
+        // reached, after the contract-visibility poll has run. This keeps the
+        // test from scripting the full balance / transfer funding pipeline while
+        // still proving the poll fired before funding from the createWallet
+        // (signAndSubmitDeploy) call site.
+        MockURLProtocol.requestHandler = { request in
+            let host = request.url?.host ?? ""
+            if host == "friendbot.stellar.org" {
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 500,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "text/plain"]
+                )!
+                return .success((response, "fail".data(using: .utf8)))
+            }
+            return MockSorobanServer.handle(request: request, script: script)
+        }
+
+        let walletOps = OZWalletOperations(kit: kit)
+        do {
+            _ = try await walletOps.createWallet(
+                userName: "Carol",
+                autoSubmit: true,
+                autoFund: true,
+                nativeTokenContract: validContractAddress2
+            )
+            XCTFail("expected SubmissionFailed once funding reaches the failing friendbot")
+        } catch is SmartAccountTransactionException.SubmissionFailed {
+            // expected: the visibility poll passed and funding reached friendbot
+        }
+
+        // Independently rebuild the contract-instance ledger key and assert the
+        // create / fund flow probed exactly that key for the deployed contract,
+        // proving the visibility poll fired with the deployed contract's id.
+        let expectedKey = try contractInstanceKeyBase64(contractId: derivedContractId)
+        let probed = script.getLedgerEntriesCalls.contains { body in
+            guard let text = String(data: body, encoding: .utf8) else { return false }
+            return text.contains(expectedKey)
+        }
+        XCTAssertTrue(
+            probed,
+            "create/fund flow must probe the contract-instance ledger key for the deployed contract"
+        )
+    }
+
     func test_deployPendingCredential_sendFailure_marksFailedAndThrows() async throws {
         let script = activatePipelineRpc()
         defer { deactivatePipelineRpc() }

--- a/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZWalletOperationsTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/smartaccount/oz/OZWalletOperationsTests.swift
@@ -1086,6 +1086,24 @@ final class OZWalletOperationsTests: XCTestCase {
         return nil
     }
 
+    /// Independently builds the Base64 `LedgerKey` for a contract's persistent
+    /// instance ledger entry (the ContractData entry keyed by the
+    /// contract-instance marker). Constructed from the raw XDR types rather than
+    /// the production helper so a wiring assertion against this value pins the
+    /// exact key the visibility poll must probe, not whatever key the production
+    /// code happens to build.
+    private func contractInstanceKeyBase64(contractId: String) throws -> String {
+        let address = try SCAddressXDR(contractId: contractId)
+        let ledgerKey = LedgerKeyXDR.contractData(
+            LedgerKeyContractDataXDR(
+                contract: address,
+                key: .ledgerKeyContractInstance,
+                durability: .persistent
+            )
+        )
+        return try XCTUnwrap(ledgerKey.xdrEncoded)
+    }
+
     // ========================================================================
     // MARK: - createWallet happy paths
     // ========================================================================
@@ -1537,6 +1555,94 @@ final class OZWalletOperationsTests: XCTestCase {
         XCTAssertEqual(kit.currentConnectedState?.contractId, derivedContractId)
         let remaining = try await storage.get(credentialId: pipelineCredentialIdB64Url)
         XCTAssertNil(remaining)
+    }
+
+    func test_deployPendingCredential_autoFund_invokesContractVisibilityPoll() async throws {
+        let script = activatePipelineRpc()
+        defer { deactivatePipelineRpc() }
+
+        let provider = RecordingWebAuthnProvider()
+        let deployer = try pipelineDeployer()
+        let storage = OZInMemoryStorageAdapter()
+        let config = try pipelineConfig(provider: provider, deployer: deployer, storage: storage)
+        let kit = MockOZSmartAccountKit(
+            config: config,
+            sorobanServer: MockSorobanServer.makeMockedSorobanServer()
+        )
+        kit.configuredDeployer = deployer
+
+        let credentialIdBytes = try Data(base64URLEncoded: pipelineCredentialIdB64Url)
+        let derivedContractId = try SmartAccountUtils.deriveContractAddress(
+            credentialId: credentialIdBytes,
+            deployerPublicKey: deployer.accountId,
+            networkPassphrase: Network.testnet.passphrase
+        )
+        let stored = OZStoredCredential(
+            credentialId: pipelineCredentialIdB64Url,
+            publicKey: generatorPointPublicKey(),
+            contractId: derivedContractId
+        )
+        try await storage.save(credential: stored)
+
+        // The deploy build fetches the deployer account and the contract
+        // visibility poll probes getLedgerEntries; the shared default returns a
+        // non-empty (deployer-account) entry, so the poll observes the contract
+        // as visible on its first probe and the flow proceeds to funding.
+        enqueueDeployerAccount(script, deployer: deployer)
+        script.enqueueSimulate(authEntries: [], minResourceFee: 50_000)
+        script.setSendSuccess(
+            status: SendTransactionResponse.STATUS_PENDING,
+            hash: "pending-deploy-hash"
+        )
+        script.setGetTransactionDefault(
+            payload: OZPipelineFixtures.validGetTransactionResponse(
+                status: GetTransactionResponse.STATUS_SUCCESS,
+                ledger: 7777
+            )
+        )
+
+        // Route friendbot to a 500 so funding throws immediately once it is
+        // reached, after the contract-visibility poll has run. This keeps the
+        // test from scripting the full balance / transfer funding pipeline while
+        // still proving the poll fired before funding.
+        MockURLProtocol.requestHandler = { request in
+            let host = request.url?.host ?? ""
+            if host == "friendbot.stellar.org" {
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 500,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "text/plain"]
+                )!
+                return .success((response, "fail".data(using: .utf8)))
+            }
+            return MockSorobanServer.handle(request: request, script: script)
+        }
+
+        let walletOps = OZWalletOperations(kit: kit)
+        do {
+            _ = try await walletOps.deployPendingCredential(
+                credentialId: pipelineCredentialIdB64Url,
+                autoFund: true,
+                nativeTokenContract: validContractAddress2
+            )
+            XCTFail("expected SubmissionFailed once funding reaches the failing friendbot")
+        } catch is SmartAccountTransactionException.SubmissionFailed {
+            // expected: the visibility poll passed and funding reached friendbot
+        }
+
+        // Independently rebuild the contract-instance ledger key and assert the
+        // deploy / fund flow probed exactly that key for the deployed contract,
+        // proving the visibility poll fired with the deployed contract's id.
+        let expectedKey = try contractInstanceKeyBase64(contractId: derivedContractId)
+        let probed = script.getLedgerEntriesCalls.contains { body in
+            guard let text = String(data: body, encoding: .utf8) else { return false }
+            return text.contains(expectedKey)
+        }
+        XCTAssertTrue(
+            probed,
+            "deploy/fund flow must probe the contract-instance ledger key for the deployed contract"
+        )
     }
 
     func test_deployPendingCredential_sendFailure_marksFailedAndThrows() async throws {


### PR DESCRIPTION
## Summary

Two improvements to the OpenZeppelin smart-account kit:

- A headless `connectToContract` that connects a smart account by its contract address alone, with no passkey credential.
- Wallet creation now polls the Soroban RPC for visibility of the funded account and the deployed contract instance, instead of waiting fixed delays.

## Headless connectToContract

`connectToContract(contractId:)` connects to an existing OZ smart account by its contract address, performing no WebAuthn ceremony and persisting no session.

The motivating use case is the agent-signer flow: an autonomous agent is granted a scoped, spend-capped Ed25519 signing authority on a smart account (an external-signer context rule) but does not own the account's passkey. Headless connect lets such an agent — or any backend service that signs through the multi-signer / external-signer path — connect by contract address alone and act as the delegated signer. A headless connection holds no passkey credential, so the single-passkey operations (`submit`, `transfer`, `contractCall`, …) reject it; calls must use the multi-signer path with an explicit signer.

New public surface:

- `OZWalletOperations.connectToContract(contractId:)` → `OZConnectToContractResult`
- a `walletConnectedHeadless` event, emitted on a headless connect, carrying only the contract address
- `OZSmartAccountKit.isHeadless`

## RPC-visibility polling

During wallet creation, two steps previously waited a fixed delay before continuing: the funded account becoming visible to the Soroban RPC, and the deployed contract instance becoming visible. A fixed delay could be too short on a slow RPC and needlessly long otherwise. Both now poll the RPC until the entry is visible, up to a bounded timeout, improving reliability.

## Compatibility

Existing passkey flows are unaffected. `OZSmartAccountKit.credentialId` is optional and now returns `nil` for a headless connection, and `isConnected` reflects the smart account's contract address being set. Code that handles connections should treat `credentialId` as genuinely optional and use `isHeadless` to distinguish a headless connection from a passkey one.
