### PR TITLE
Check secure random generation status in mnemonic creation

### DIFF
--- a/stellarsdk/stellarsdk/libs/HDWallet/Mnemonic.swift
+++ b/stellarsdk/stellarsdk/libs/HDWallet/Mnemonic.swift
@@ -54,7 +54,7 @@ public final class Mnemonic: Sendable {
         let byteCount = strength.rawValue / 8
         var bytes = Data(count: byteCount)
         bytes.withUnsafeMutableBytes { buffer in
-            _ = SecRandomCopyBytes(kSecRandomDefault, byteCount, buffer.baseAddress!)
+            precondition(SecRandomCopyBytes(kSecRandomDefault, byteCount, buffer.baseAddress!) == errSecSuccess, "Secure random generation failed")
         }
         return create(entropy: bytes, language: language)
     }


### PR DESCRIPTION
## Summary

Check the status returned by `SecRandomCopyBytes` before using the generated entropy to create a BIP-39 mnemonic.

## Rationale

`Mnemonic.create(strength:language:)` currently ignores the random generator status and always passes the entropy buffer to `Mnemonic.create(entropy:language:)`.

This change fails closed if secure random generation is unsuccessful.

The successful path is unchanged: it uses the same entropy size, system random source, language, checksum calculation, and mnemonic encoding. The public API also remains unchanged.

## Verification

- `swift build`
