### PR TITLE
Resolve CAP-85 external reference executables when loading contracts

### DIFF
--- a/stellarsdk/stellarsdk/soroban/SorobanServer.swift
+++ b/stellarsdk/stellarsdk/soroban/SorobanServer.swift
@@ -150,6 +150,16 @@ public enum GetContractCodeResponseEnum: Sendable {
     case failure(error: SorobanRpcRequestError)
 }
 
+/// Response enum for external reference resolution requests.
+///
+/// Returns the 32-byte wasm hash a CAP-85 external reference names.
+public enum GetExternalRefWasmHashResponseEnum: Sendable {
+    /// Successfully resolved the external reference to its wasm hash.
+    case success(response: Data)
+    /// Failed to resolve the external reference, error details in associated value.
+    case failure(error: SorobanRpcRequestError)
+}
+
 /// Response enum for contract information requests.
 ///
 /// Returns parsed contract metadata including spec entries, environment info, and contract metadata.
@@ -576,6 +586,12 @@ public class SorobanServer: @unchecked Sendable {
     
     /// Loads the contract code (wasm binary) for the given contractId.
     ///
+    /// The contract instance's executable decides how the code is found: a wasm
+    /// executable carries the hash directly, a CAP-85 external reference is resolved
+    /// through the owner contract's tag entry via `getExternalRefWasmHash(ref:)`, and a
+    /// Stellar Asset Contract has no wasm bytecode on chain and fails with a message
+    /// saying so.
+    ///
     /// - Parameter contractId: Stellar contract address (C...)
     /// - Returns: Contract code entry containing the WASM bytecode
     public func getContractCodeForContractId(contractId: String) async -> GetContractCodeResponseEnum {
@@ -587,27 +603,32 @@ public class SorobanServer: @unchecked Sendable {
         } catch {
             return .failure(error: .requestFailed(message: "invalid contract id"))
         }
-        
+
         let ledgerKey = LedgerKeyXDR.contractData(contractDataKey!)
         if let ledgerKeyBase64 = ledgerKey.xdrEncoded {
             let response = await self.getLedgerEntries(base64EncodedKeys: [ledgerKeyBase64])
             switch response {
             case .success(let response):
                 guard let firstEntry = response.entries.first else {
-                    return .failure(error: .requestFailed(message: "could not extract wasm id"))
+                    return .failure(error: .requestFailed(message: "no contract instance entry found for contract id \(contractId)"))
                 }
                 let data = try? LedgerEntryDataXDR(fromBase64: firstEntry.xdr)
-                if let contractData = data?.contractData, let wasmId = contractData.val.contractInstance?.executable.wasm?.wrapped.base16EncodedString() {
-                    let response = await self.getContractCodeForWasmId(wasmId: wasmId)
-                    switch response {
-                    case .success(let response):
-                        return .success(response: response)
+                guard let instance = data?.contractData?.val.contractInstance else {
+                    return .failure(error: .requestFailed(message: "ledger entry for contract id \(contractId) is not a contract instance"))
+                }
+                switch instance.executable {
+                case .wasm(let hash):
+                    return await self.getContractCodeForWasmId(wasmId: hash.wrapped.base16EncodedString())
+                case .externalRef(let ref):
+                    let hashResponse = await self.getExternalRefWasmHash(ref: ref)
+                    switch hashResponse {
+                    case .success(let wasmHash):
+                        return await self.getContractCodeForWasmId(wasmId: wasmHash.base16EncodedString())
                     case .failure(let error):
                         return .failure(error: error)
                     }
-                }
-                else {
-                    return .failure(error: .requestFailed(message: "could not extract wasm id"))
+                case .token:
+                    return .failure(error: .requestFailed(message: "contract \(contractId) is a Stellar Asset Contract and has no wasm bytecode on chain"))
                 }
             case .failure(let error):
                 return .failure(error: error)
@@ -617,6 +638,52 @@ public class SorobanServer: @unchecked Sendable {
         }
     }
     
+    /// Resolves a CAP-85 external reference to the 32-byte wasm hash it names.
+    ///
+    /// A contract created from an external reference does not carry its own code hash.
+    /// The reference names an owner contract and a tag, and the owner holds a persistent
+    /// contract data entry keyed by that tag whose value is the 32-byte hash of an
+    /// already uploaded wasm. This method reads that entry off the ledger; the owner
+    /// contract is not invoked. The tag entry is matched byte for byte, so the tag is
+    /// passed through exactly as the reference carries it.
+    ///
+    /// The failure message states which condition fired: the owner is not a contract
+    /// address, the owner has no entry under the tag (missing or archived), the entry
+    /// is not a contract data entry, or the entry value does not hold a 32-byte wasm
+    /// hash. RPC transport errors are propagated unchanged.
+    ///
+    /// - Parameter ref: The external reference naming the owner contract and the tag
+    /// - Returns: The 32-byte wasm hash on success
+    public func getExternalRefWasmHash(ref: ContractExecutableExternalRefXDR) async -> GetExternalRefWasmHashResponseEnum {
+        guard case .contract = ref.executableOwner, let ownerHex = ref.executableOwner.contractId else {
+            let described = ref.executableOwner.accountId ?? ref.executableOwner.liquidityPoolId ?? ref.executableOwner.claimableBalanceId ?? "of an unsupported address type"
+            return .failure(error: .requestFailed(message: "external reference owner \(described) is not a contract address; only a contract can hold the executable tag entry"))
+        }
+        let owner = (try? ownerHex.encodeContractIdHex()) ?? ownerHex
+        let contractDataKey = LedgerKeyContractDataXDR(contract: ref.executableOwner,
+                                                       key: SCValXDR.executableTag(ref.tag),
+                                                       durability: ContractDataDurability.persistent)
+        let ledgerKey = LedgerKeyXDR.contractData(contractDataKey)
+        guard let ledgerKeyBase64 = ledgerKey.xdrEncoded else { return .failure(error: .requestFailed(message: "could not create ledger key")) }
+        let response = await self.getLedgerEntries(base64EncodedKeys: [ledgerKeyBase64])
+        switch response {
+        case .success(let response):
+            guard let firstEntry = response.entries.first else {
+                return .failure(error: .requestFailed(message: "no executable tag entry found on owner contract \(owner) for tag \(ref.tag)"))
+            }
+            let data = try? LedgerEntryDataXDR(fromBase64: firstEntry.xdr)
+            guard let contractData = data?.contractData else {
+                return .failure(error: .requestFailed(message: "executable tag entry on owner contract \(owner) is not a contract data entry"))
+            }
+            guard let wasmHash = contractData.val.bytes, wasmHash.count == 32 else {
+                return .failure(error: .requestFailed(message: "executable tag entry on owner contract \(owner) does not hold a 32-byte wasm hash"))
+            }
+            return .success(response: wasmHash)
+        case .failure(let error):
+            return .failure(error: error)
+        }
+    }
+
     /// Loads contract source byte code for the given contractId and extracts
     /// the information (Environment Meta, Contract Spec, Contract Meta).
     ///

--- a/stellarsdk/stellarsdkIntegrationTests/soroban/SorobanP28ExternalRefIntegrationTests.swift
+++ b/stellarsdk/stellarsdkIntegrationTests/soroban/SorobanP28ExternalRefIntegrationTests.swift
@@ -1,0 +1,177 @@
+//
+//  SorobanP28ExternalRefIntegrationTests.swift
+//  stellarsdkIntegrationTests
+//
+//  Created by Soneso on 18.08.26.
+//  Copyright © 2026 Soneso. All rights reserved.
+//
+
+import XCTest
+import stellarsdk
+
+/// Verifies CAP-85 external reference resolution against a live network.
+///
+/// `testExternalRefLedgerKeyAcceptedByRpc` is self-contained: it deploys its
+/// own contract and checks that the RPC accepts the executable tag ledger key
+/// the resolver builds. `testLoadExternalRefContract` reads an external-ref
+/// contract that already exists on the network; its contract id comes from the
+/// environment variable `STELLAR_P28_EXTERNAL_REF_CONTRACT_ID`, which must
+/// name a contract deployed with a CAP-85 external reference executable, and
+/// the test skips when the variable is unset. Both tests skip when the network
+/// runs a protocol below 28.
+final class SorobanP28ExternalRefIntegrationTests: XCTestCase {
+
+    static let testOn = "testnet" // "futurenet"
+    let sorobanServer = testOn == "testnet" ? SorobanServer(endpoint: "https://soroban-testnet.stellar.org"): SorobanServer(endpoint: "https://rpc-futurenet.stellar.org")
+    let rpcUrl = testOn == "testnet" ? "https://soroban-testnet.stellar.org" : "https://rpc-futurenet.stellar.org"
+    let network = testOn == "testnet" ? Network.testnet : Network.futurenet
+
+    func testExternalRefLedgerKeyAcceptedByRpc() async throws {
+        let protocolVersion = try await fetchProtocolVersion()
+        guard protocolVersion >= 28 else {
+            throw XCTSkip("Network runs protocol \(protocolVersion); skipping P28 external-ref key test")
+        }
+
+        let keyPair = try KeyPair.generateRandomKeyPair()
+        try await fundTestAccountAndAwaitVisibility(accountId: keyPair.accountId,
+                                                    rpc: sorobanServer,
+                                                    useFuturenet: Self.testOn != "testnet")
+        let wasmHash = try await installContract(fileName: "soroban_hello_world_contract",
+                                                 sourceAccountKeyPair: keyPair)
+        let client = try await deployContract(wasmHash: wasmHash, sourceAccountKeyPair: keyPair)
+        let contractId = client.contractId
+
+        // The executable dispatch still loads a wasm instance from the live ledger.
+        let codeResponse = await sorobanServer.getContractCodeForContractId(contractId: contractId)
+        guard case .success(let codeEntry) = codeResponse else {
+            XCTFail("getContractCodeForContractId failed: \(codeResponse)")
+            return
+        }
+        XCTAssertFalse(codeEntry.code.isEmpty)
+
+        // The RPC must accept the executable tag ledger key the resolver builds,
+        // answering an empty entry list for a tag no entry exists under. The
+        // response is asserted directly because a resolver failure would not
+        // distinguish an accepted-but-absent key from a rejected request.
+        let unusedTag = "no entry exists under this tag"
+        let owner = try SCAddressXDR(contractId: contractId)
+        let tagKey = LedgerKeyXDR.contractData(LedgerKeyContractDataXDR(
+            contract: owner,
+            key: SCValXDR.executableTag(unusedTag),
+            durability: ContractDataDurability.persistent))
+        let entriesResponse = await sorobanServer.getLedgerEntries(base64EncodedKeys: [tagKey.xdrEncoded!])
+        guard case .success(let entriesResult) = entriesResponse else {
+            XCTFail("RPC rejected the executable tag ledger key: \(entriesResponse)")
+            return
+        }
+        XCTAssertTrue(entriesResult.entries.isEmpty)
+
+        // The resolver reports the same absence with its missing-entry message.
+        let ref = ContractExecutableExternalRefXDR(executableOwner: owner, tag: unusedTag)
+        let hashResponse = await sorobanServer.getExternalRefWasmHash(ref: ref)
+        guard case .failure(let error) = hashResponse,
+              case SorobanRpcRequestError.requestFailed(let message) = error else {
+            XCTFail("expected the missing-entry failure, got \(hashResponse)")
+            return
+        }
+        XCTAssertTrue(message.contains("no executable tag entry found"),
+                      "unexpected message: \(message)")
+    }
+
+    func testLoadExternalRefContract() async throws {
+        let protocolVersion = try await fetchProtocolVersion()
+        guard protocolVersion >= 28 else {
+            throw XCTSkip("Network runs protocol \(protocolVersion); skipping P28 external-ref test")
+        }
+        guard let contractId = ProcessInfo.processInfo.environment["STELLAR_P28_EXTERNAL_REF_CONTRACT_ID"] else {
+            throw XCTSkip("STELLAR_P28_EXTERNAL_REF_CONTRACT_ID not set; skipping P28 external-ref test")
+        }
+
+        // Read the instance the same way getContractCodeForContractId does and
+        // require the external-ref arm. A fixture pointing at a contract with a
+        // different executable is a broken fixture and must be visible.
+        let dataResponse = await sorobanServer.getContractData(contractId: contractId,
+                                                               key: SCValXDR.ledgerKeyContractInstance,
+                                                               durability: ContractDataDurability.persistent)
+        guard case .success(let entry) = dataResponse else {
+            XCTFail("could not read contract instance for \(contractId): \(dataResponse)")
+            return
+        }
+        let entryData = try LedgerEntryDataXDR(fromBase64: entry.xdr)
+        guard let executable = entryData.contractData?.val.contractInstance?.executable else {
+            XCTFail("ledger entry for \(contractId) is not a contract instance")
+            return
+        }
+        guard case .externalRef(let ref) = executable else {
+            XCTFail("fixture contract \(contractId) does not carry an external-ref executable; its executable is \(executable)")
+            return
+        }
+
+        // The reference resolves to a 32-byte wasm hash.
+        let hashResponse = await sorobanServer.getExternalRefWasmHash(ref: ref)
+        guard case .success(let wasmHash) = hashResponse else {
+            XCTFail("getExternalRefWasmHash failed: \(hashResponse)")
+            return
+        }
+        XCTAssertEqual(wasmHash.count, 32)
+
+        // The code loader resolves the reference and returns the code entry of
+        // exactly that hash.
+        let codeResponse = await sorobanServer.getContractCodeForContractId(contractId: contractId)
+        guard case .success(let codeEntry) = codeResponse else {
+            XCTFail("getContractCodeForContractId failed: \(codeResponse)")
+            return
+        }
+        XCTAssertEqual(codeEntry.hash.wrapped, wasmHash)
+        XCTAssertFalse(codeEntry.code.isEmpty)
+
+        // The info loader parses the code behind the reference.
+        let infoResponse = await sorobanServer.getContractInfoForContractId(contractId: contractId)
+        guard case .success(let info) = infoResponse else {
+            XCTFail("getContractInfoForContractId failed: \(infoResponse)")
+            return
+        }
+        XCTAssertFalse(info.specEntries.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    /// Returns the current ledger protocol version from the RPC.
+    private func fetchProtocolVersion() async throws -> Int {
+        let response = await sorobanServer.getLatestLedger()
+        switch response {
+        case .success(let ledger):
+            return ledger.protocolVersion
+        case .failure(let error):
+            XCTFail("getLatestLedger failed: \(error)")
+            return 0
+        }
+    }
+
+    private func installContract(fileName: String, sourceAccountKeyPair: KeyPair) async throws -> String {
+        guard let path = Bundle.module.path(forResource: fileName, ofType: "wasm"),
+              let contractCode = FileManager.default.contents(atPath: path) else {
+            XCTFail("\(fileName).wasm not found in test bundle")
+            return ""
+        }
+        let installRequest = InstallRequest(
+            rpcUrl: rpcUrl,
+            network: network,
+            sourceAccountKeyPair: sourceAccountKeyPair,
+            wasmBytes: contractCode,
+            enableServerLogging: false
+        )
+        return try await SorobanClient.install(installRequest: installRequest)
+    }
+
+    private func deployContract(wasmHash: String, sourceAccountKeyPair: KeyPair) async throws -> SorobanClient {
+        let deployRequest = DeployRequest(
+            rpcUrl: rpcUrl,
+            network: network,
+            sourceAccountKeyPair: sourceAccountKeyPair,
+            wasmHash: wasmHash,
+            enableServerLogging: false
+        )
+        return try await SorobanClient.deploy(deployRequest: deployRequest)
+    }
+}

--- a/stellarsdk/stellarsdkUnitTests/soroban/SorobanServerExternalRefUnitTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/soroban/SorobanServerExternalRefUnitTests.swift
@@ -1,0 +1,484 @@
+//
+//  SorobanServerExternalRefUnitTests.swift
+//  stellarsdkUnitTests
+//
+//  Created by Soneso on 18.08.26.
+//  Copyright © 2026 Soneso. All rights reserved.
+//
+
+import XCTest
+@testable import stellarsdk
+
+/// Tests for CAP-85 external reference resolution in SorobanServer.
+///
+/// All RPC calls are served by ServerMock; no network access. The mock answers
+/// only requests carrying the exact base64 ledger key a test expects, so a key
+/// built with the wrong type, owner, tag or durability goes unanswered and the
+/// request log exposes it.
+final class SorobanServerExternalRefUnitTests: XCTestCase {
+
+    var mockRpcUrl: String!
+    var server: SorobanServer!
+    var mockContractId: String!
+    var ownerContractIdHex: String!
+    var executableTag: String!
+    var wasmHashBytes: Data!
+    var keyPair: KeyPair!
+    var tokenWasm: Data!
+
+    /// Records the base64 ledger key of every served getLedgerEntries request,
+    /// or "unmatched" for a request no expected key matched.
+    private final class RequestLog: @unchecked Sendable {
+        var entries: [String] = []
+    }
+    private var requestLog = RequestLog()
+
+    override func setUp() {
+        super.setUp()
+
+        URLProtocol.registerClass(ServerMock.self)
+
+        mockRpcUrl = "https://soroban-testnet.stellar.org"
+        mockContractId = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+        ownerContractIdHex = "c0decafec0decafec0decafec0decafec0decafec0decafec0decafec0decafe"
+        executableTag = "token-v1"
+        wasmHashBytes = Data(repeating: 3, count: 32)
+        keyPair = try! KeyPair.generateRandomKeyPair()
+        server = SorobanServer(endpoint: mockRpcUrl)
+        requestLog = RequestLog()
+
+        guard let path = Bundle.module.path(forResource: "soroban_token_contract", ofType: "wasm"),
+              let wasm = FileManager.default.contents(atPath: path) else {
+            XCTFail("Failed to load soroban_token_contract.wasm")
+            return
+        }
+        tokenWasm = wasm
+    }
+
+    override func tearDown() {
+        ServerMock.removeAll()
+        URLProtocol.unregisterClass(ServerMock.self)
+        super.tearDown()
+    }
+
+    // MARK: - Fixtures
+
+    private func ownerAddress() -> SCAddressXDR {
+        return try! SCAddressXDR(contractId: ownerContractIdHex)
+    }
+
+    private func externalRef(tag: String? = nil, owner: SCAddressXDR? = nil) -> ContractExecutableExternalRefXDR {
+        return ContractExecutableExternalRefXDR(executableOwner: owner ?? ownerAddress(),
+                                                tag: tag ?? executableTag)
+    }
+
+    private func instanceKeyB64() -> String {
+        let key = LedgerKeyXDR.contractData(LedgerKeyContractDataXDR(
+            contract: try! SCAddressXDR(contractId: mockContractId),
+            key: SCValXDR.ledgerKeyContractInstance,
+            durability: .persistent))
+        return key.xdrEncoded!
+    }
+
+    private func tagKeyB64() -> String {
+        let key = LedgerKeyXDR.contractData(LedgerKeyContractDataXDR(
+            contract: ownerAddress(),
+            key: SCValXDR.executableTag(executableTag),
+            durability: .persistent))
+        return key.xdrEncoded!
+    }
+
+    private func codeKeyB64() -> String {
+        let key = LedgerKeyXDR.contractCode(try! LedgerKeyContractCodeXDR(wasmId: wasmHashBytes.base16EncodedString()))
+        return key.xdrEncoded!
+    }
+
+    private func instanceEntry(executable: ContractExecutableXDR) -> LedgerEntryDataXDR {
+        let instance = SCContractInstanceXDR(executable: executable, storage: nil)
+        return LedgerEntryDataXDR.contractData(ContractDataEntryXDR(
+            ext: .void,
+            contract: try! SCAddressXDR(contractId: mockContractId),
+            key: SCValXDR.ledgerKeyContractInstance,
+            durability: .persistent,
+            val: SCValXDR.contractInstance(instance)))
+    }
+
+    private func tagEntry(val: SCValXDR) -> LedgerEntryDataXDR {
+        return LedgerEntryDataXDR.contractData(ContractDataEntryXDR(
+            ext: .void,
+            contract: ownerAddress(),
+            key: SCValXDR.executableTag(executableTag),
+            durability: .persistent,
+            val: val))
+    }
+
+    private func codeEntry(code: Data) -> LedgerEntryDataXDR {
+        return LedgerEntryDataXDR.contractCode(ContractCodeEntryXDR(
+            ext: .void,
+            hash: WrappedData32(wasmHashBytes),
+            code: code))
+    }
+
+    // MARK: - Mock setup
+
+    /// Serves getLedgerEntries requests from [answers]: the response for a
+    /// request is the entry stored under the exact base64 ledger key its body
+    /// carries, or an empty entry list when the stored value is nil. Requests
+    /// carrying a key that is not in [answers] are logged as "unmatched" and
+    /// answered with an empty entry list.
+    private func setupMock(answers: [String: LedgerEntryDataXDR?]) {
+        let log = requestLog
+        let mock = RequestMock(
+            host: "soroban-testnet.stellar.org",
+            path: "*",
+            httpMethod: "POST"
+        ) { mock, request in
+            var body = request.httpBody
+            if body == nil, let stream = request.httpBodyStream {
+                body = stream.readfully()
+            }
+            guard let bodyData = body,
+                  let rawBody = String(data: bodyData, encoding: .utf8),
+                  rawBody.contains("getLedgerEntries") else {
+                return nil
+            }
+            // JSON serialization escapes "/" in the base64 keys as "\/".
+            let bodyString = rawBody.replacingOccurrences(of: "\\/", with: "/")
+            mock.statusCode = 200
+            for (keyB64, entry) in answers where bodyString.contains(keyB64) {
+                log.entries.append(keyB64)
+                guard let entry = entry else {
+                    return self.emptyEntriesJson()
+                }
+                return self.ledgerEntryResponseJson(entryData: entry)
+            }
+            log.entries.append("unmatched")
+            return self.emptyEntriesJson()
+        }
+        ServerMock.add(mock: mock)
+    }
+
+    private func emptyEntriesJson() -> String {
+        return """
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "entries": [],
+                "latestLedger": 1000000
+            }
+        }
+        """
+    }
+
+    private func ledgerEntryResponseJson(entryData: LedgerEntryDataXDR) -> String {
+        return """
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "entries": [
+                    {
+                        "key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                        "xdr": "\(entryData.xdrEncoded!)",
+                        "lastModifiedLedgerSeq": 999000
+                    }
+                ],
+                "latestLedger": 1000000
+            }
+        }
+        """
+    }
+
+    private func resolverFailureMessage(_ result: GetExternalRefWasmHashResponseEnum) -> String? {
+        if case .failure(let error) = result,
+           case SorobanRpcRequestError.requestFailed(let message) = error {
+            return message
+        }
+        return nil
+    }
+
+    private func codeFailureMessage(_ result: GetContractCodeResponseEnum) -> String? {
+        if case .failure(let error) = result,
+           case SorobanRpcRequestError.requestFailed(let message) = error {
+            return message
+        }
+        return nil
+    }
+
+    // MARK: - Tests
+
+    func testWasmArmStillLoadsCode() async throws {
+        let wasm = Data([0, 97, 115, 109])
+        setupMock(answers: [
+            instanceKeyB64(): instanceEntry(executable: .wasm(WrappedData32(wasmHashBytes))),
+            codeKeyB64(): codeEntry(code: wasm),
+        ])
+
+        let result = await server.getContractCodeForContractId(contractId: mockContractId)
+
+        guard case .success(let response) = result else {
+            XCTFail("Expected success, got \(result)")
+            return
+        }
+        XCTAssertEqual(response.code, wasm)
+        XCTAssertEqual(requestLog.entries, [instanceKeyB64(), codeKeyB64()])
+    }
+
+    func testExternalRefResolvesThroughOwnerTagEntry() async throws {
+        let wasm = Data([0, 97, 115, 109, 1])
+        setupMock(answers: [
+            instanceKeyB64(): instanceEntry(executable: .externalRef(externalRef())),
+            tagKeyB64(): tagEntry(val: SCValXDR.bytes(wasmHashBytes)),
+            codeKeyB64(): codeEntry(code: wasm),
+        ])
+
+        let result = await server.getContractCodeForContractId(contractId: mockContractId)
+
+        guard case .success(let response) = result else {
+            XCTFail("Expected success, got \(result)")
+            return
+        }
+        XCTAssertEqual(response.code, wasm)
+        // The request sequence pins the resolution: the tag key carries the
+        // executable tag on the owner at persistent durability, and the code
+        // key carries the hash the tag entry held.
+        XCTAssertEqual(requestLog.entries, [instanceKeyB64(), tagKeyB64(), codeKeyB64()])
+    }
+
+    func testResolverReturnsTheHashTheTagEntryHolds() async throws {
+        setupMock(answers: [tagKeyB64(): tagEntry(val: SCValXDR.bytes(wasmHashBytes))])
+
+        let result = await server.getExternalRefWasmHash(ref: externalRef())
+
+        guard case .success(let hash) = result else {
+            XCTFail("Expected success, got \(result)")
+            return
+        }
+        XCTAssertEqual(hash, wasmHashBytes)
+    }
+
+    func testMissingTagEntryFails() async throws {
+        setupMock(answers: [
+            instanceKeyB64(): instanceEntry(executable: .externalRef(externalRef())),
+            tagKeyB64(): nil,
+        ])
+
+        let direct = await server.getExternalRefWasmHash(ref: externalRef())
+        guard let directMessage = resolverFailureMessage(direct) else {
+            XCTFail("Expected requestFailed, got \(direct)")
+            return
+        }
+        XCTAssertTrue(directMessage.contains("no executable tag entry found on owner contract"),
+                      "unexpected message: \(directMessage)")
+        XCTAssertTrue(directMessage.contains(executableTag), "unexpected message: \(directMessage)")
+
+        let viaLoader = await server.getContractCodeForContractId(contractId: mockContractId)
+        guard let loaderMessage = codeFailureMessage(viaLoader) else {
+            XCTFail("Expected requestFailed, got \(viaLoader)")
+            return
+        }
+        XCTAssertEqual(loaderMessage, directMessage)
+        XCTAssertEqual(requestLog.entries, [tagKeyB64(), instanceKeyB64(), tagKeyB64()])
+    }
+
+    func testMissingInstanceEntryFails() async throws {
+        setupMock(answers: [instanceKeyB64(): nil])
+
+        let result = await server.getContractCodeForContractId(contractId: mockContractId)
+
+        guard let message = codeFailureMessage(result) else {
+            XCTFail("Expected requestFailed, got \(result)")
+            return
+        }
+        XCTAssertTrue(message.contains("no contract instance entry found for contract id"),
+                      "unexpected message: \(message)")
+        XCTAssertTrue(message.contains(mockContractId), "unexpected message: \(message)")
+        XCTAssertEqual(requestLog.entries, [instanceKeyB64()])
+    }
+
+    func testTagEntryWithNonBytesValueFails() async throws {
+        setupMock(answers: [tagKeyB64(): tagEntry(val: SCValXDR.symbol("not_a_hash"))])
+
+        let result = await server.getExternalRefWasmHash(ref: externalRef())
+
+        guard let message = resolverFailureMessage(result) else {
+            XCTFail("Expected requestFailed, got \(result)")
+            return
+        }
+        XCTAssertTrue(message.contains("does not hold a 32-byte wasm hash"),
+                      "unexpected message: \(message)")
+    }
+
+    func testTagEntryWithWrongLengthBytesFails() async throws {
+        for length in [31, 33] {
+            ServerMock.removeAll()
+            setupMock(answers: [tagKeyB64(): tagEntry(val: SCValXDR.bytes(Data(repeating: 1, count: length)))])
+
+            let result = await server.getExternalRefWasmHash(ref: externalRef())
+
+            guard let message = resolverFailureMessage(result) else {
+                XCTFail("Expected requestFailed for length \(length), got \(result)")
+                return
+            }
+            XCTAssertTrue(message.contains("does not hold a 32-byte wasm hash"),
+                          "unexpected message for length \(length): \(message)")
+        }
+    }
+
+    func testNonContractOwnerFailsWithoutRequest() async throws {
+        setupMock(answers: [:])
+        let accountOwner = try SCAddressXDR(accountId: keyPair.accountId)
+
+        let result = await server.getExternalRefWasmHash(ref: externalRef(owner: accountOwner))
+
+        guard let message = resolverFailureMessage(result) else {
+            XCTFail("Expected requestFailed, got \(result)")
+            return
+        }
+        XCTAssertTrue(message.contains("is not a contract address"),
+                      "unexpected message: \(message)")
+        XCTAssertTrue(message.contains(keyPair.accountId),
+                      "message does not name the owner: \(message)")
+        XCTAssertEqual(requestLog.entries, [])
+    }
+
+    func testLiquidityPoolOwnerFailsWithoutRequest() async throws {
+        setupMock(answers: [:])
+        let poolOwner = try SCAddressXDR(liquidityPoolId: ownerContractIdHex)
+
+        let result = await server.getExternalRefWasmHash(ref: externalRef(owner: poolOwner))
+
+        guard let message = resolverFailureMessage(result) else {
+            XCTFail("Expected requestFailed, got \(result)")
+            return
+        }
+        XCTAssertTrue(message.contains("is not a contract address"),
+                      "unexpected message: \(message)")
+        XCTAssertTrue(message.contains(ownerContractIdHex),
+                      "message does not name the owner: \(message)")
+        XCTAssertEqual(requestLog.entries, [])
+    }
+
+    func testClaimableBalanceOwnerFailsWithoutRequest() async throws {
+        setupMock(answers: [:])
+        let balanceOwner = try SCAddressXDR(claimableBalanceId: "00000000" + ownerContractIdHex)
+
+        let result = await server.getExternalRefWasmHash(ref: externalRef(owner: balanceOwner))
+
+        guard let message = resolverFailureMessage(result) else {
+            XCTFail("Expected requestFailed, got \(result)")
+            return
+        }
+        XCTAssertTrue(message.contains("is not a contract address"),
+                      "unexpected message: \(message)")
+        XCTAssertTrue(message.contains(balanceOwner.claimableBalanceId!),
+                      "message does not name the owner: \(message)")
+        XCTAssertEqual(requestLog.entries, [])
+    }
+
+    func testRpcErrorPropagatesUnchangedFromResolver() async throws {
+        let mock = RequestMock(host: "soroban-testnet.stellar.org",
+                               path: "*",
+                               httpMethod: "POST") { mock, request in
+            mock.statusCode = 200
+            return """
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {"code": -32603, "message": "Internal error"}
+            }
+            """
+        }
+        ServerMock.add(mock: mock)
+
+        let result = await server.getExternalRefWasmHash(ref: externalRef())
+
+        guard case .failure(let error) = result,
+              case SorobanRpcRequestError.errorResponse(let rpcError) = error else {
+            XCTFail("Expected errorResponse, got \(result)")
+            return
+        }
+        XCTAssertEqual(rpcError.code, -32603)
+        XCTAssertEqual(rpcError.message, "Internal error")
+    }
+
+    func testTagEntryThatIsNotContractDataFails() async throws {
+        setupMock(answers: [tagKeyB64(): codeEntry(code: Data([1, 2, 3]))])
+
+        let result = await server.getExternalRefWasmHash(ref: externalRef())
+
+        guard let message = resolverFailureMessage(result) else {
+            XCTFail("Expected requestFailed, got \(result)")
+            return
+        }
+        XCTAssertTrue(message.contains("is not a contract data entry"),
+                      "unexpected message: \(message)")
+    }
+
+    func testInstanceEntryThatIsNotAContractInstanceFails() async throws {
+        let notAnInstance = LedgerEntryDataXDR.contractData(ContractDataEntryXDR(
+            ext: .void,
+            contract: try! SCAddressXDR(contractId: mockContractId),
+            key: SCValXDR.ledgerKeyContractInstance,
+            durability: .persistent,
+            val: SCValXDR.symbol("x")))
+        setupMock(answers: [instanceKeyB64(): notAnInstance])
+
+        let result = await server.getContractCodeForContractId(contractId: mockContractId)
+
+        guard let message = codeFailureMessage(result) else {
+            XCTFail("Expected requestFailed, got \(result)")
+            return
+        }
+        XCTAssertTrue(message.contains("is not a contract instance"),
+                      "unexpected message: \(message)")
+    }
+
+    func testStellarAssetContractFails() async throws {
+        setupMock(answers: [instanceKeyB64(): instanceEntry(executable: .token)])
+
+        let result = await server.getContractCodeForContractId(contractId: mockContractId)
+
+        guard let message = codeFailureMessage(result) else {
+            XCTFail("Expected requestFailed, got \(result)")
+            return
+        }
+        XCTAssertTrue(message.contains("Stellar Asset Contract"), "unexpected message: \(message)")
+        XCTAssertEqual(requestLog.entries, [instanceKeyB64()])
+    }
+
+    func testClientForClientOptionsResolvesExternalRef() async throws {
+        setupMock(answers: [
+            instanceKeyB64(): instanceEntry(executable: .externalRef(externalRef())),
+            tagKeyB64(): tagEntry(val: SCValXDR.bytes(wasmHashBytes)),
+            codeKeyB64(): codeEntry(code: tokenWasm),
+        ])
+
+        let client = try await SorobanClient.forClientOptions(options: ClientOptions(
+            sourceAccountKeyPair: keyPair,
+            contractId: mockContractId,
+            network: Network.testnet,
+            rpcUrl: mockRpcUrl,
+            enableServerLogging: false))
+
+        XCTAssertTrue(client.methodNames.contains("transfer"))
+    }
+
+    func testTagSurvivesXdrRoundTripIntoTheSameLedgerKey() throws {
+        let tag = "tøken-\u{0000}-火"
+        let writtenKey = SCValXDR.executableTag(tag).xdrEncoded!
+
+        let instanceVal = SCValXDR.contractInstance(SCContractInstanceXDR(
+            executable: .externalRef(ContractExecutableExternalRefXDR(executableOwner: ownerAddress(), tag: tag)),
+            storage: nil))
+        let decoded = try SCValXDR.fromXdr(base64: instanceVal.xdrEncoded!)
+
+        guard let decodedTag = decoded.contractInstance?.executable.externalRef?.tag else {
+            XCTFail("decoded value carries no external ref tag")
+            return
+        }
+        XCTAssertEqual(decodedTag, tag)
+        XCTAssertEqual(SCValXDR.executableTag(decodedTag).xdrEncoded!, writtenKey)
+    }
+}


### PR DESCRIPTION
A contract created from a CAP-85 external reference (Protocol 28) does not carry its own wasm hash. The instance names an owner contract and a tag, and the owner holds a persistent contract data entry under that tag whose value is the hash of an already uploaded wasm. The contract loading paths read only the wasm arm, so `getContractCodeForContractId` failed with "could not extract wasm id" for such a contract, `getContractInfoForContractId` inherited the failure, and no `SorobanClient` could be built for it.

`getContractCodeForContractId` now dispatches on the executable arm: the wasm arm loads as before, an external reference resolves through the owner's tag entry, and a Stellar Asset Contract fails with a message saying it has no wasm bytecode on chain. `getContractInfoForContractId` and `SorobanClient.forClientOptions` inherit the resolution. The previously shared "could not extract wasm id" failure message is split per condition: a missing instance entry, a ledger entry that is not a contract instance, and the Stellar Asset Contract case each report their own message. Callers matching on the old string see the change.

The new `SorobanServer.getExternalRefWasmHash(ref:)` resolves a reference directly, answering with the new `GetExternalRefWasmHashResponseEnum`: `.success` carries the 32-byte hash, `.failure` a `SorobanRpcRequestError` whose message names the condition that fired: the owner is not a contract address, no entry exists under the tag, the entry is not a contract data entry, or the value is not a 32-byte wasm hash. Resolution costs one additional `getLedgerEntries` call; the owner contract is read, never invoked.

Unit tests answer only requests carrying the exact expected ledger key, pinning the executable-tag key, the persistent durability, the code key derived from the resolved hash, and a tag with NUL and multi-byte characters passing through byte for byte. Both integration tests skip below protocol 28. One deploys its own contract and asserts a protocol 28 RPC accepts the executable tag ledger key the resolver builds. The other reads an external-ref contract named by `STELLAR_P28_EXTERNAL_REF_CONTRACT_ID` and skips while that variable is unset.
