### PR TITLE
Fix anchor request field rendering and remove LedgerEntryDataXDR.isBool

### DIFF
--- a/stellarsdk/stellarsdk/interactive/InteractiveService.swift
+++ b/stellarsdk/stellarsdk/interactive/InteractiveService.swift
@@ -299,7 +299,7 @@ public final class InteractiveService: @unchecked Sendable {
     /// - Parameter request: Sep24FeeRequest containing operation type, asset code, amount, and JWT token
     /// - Returns: Sep24FeeResponseEnum with fee amount, or an error
     public func fee(request: Sep24FeeRequest) async -> Sep24FeeResponseEnum {
-        var requestPath = "/fee?operation=\(request.operation.urlQueryValueEncoded)&asset_code=\(request.assetCode.urlQueryValueEncoded)&amount=\(String(request.amount).urlQueryValueEncoded)"
+        var requestPath = "/fee?operation=\(request.operation.urlQueryValueEncoded)&asset_code=\(request.assetCode.urlQueryValueEncoded)&amount=\(SepRequestAmount.format(request.amount).urlQueryValueEncoded)"
 
         if let type = request.type {
             requestPath += "&type=\(type.urlQueryValueEncoded)"

--- a/stellarsdk/stellarsdk/kyc/KycAmlFields.swift
+++ b/stellarsdk/stellarsdk/kyc/KycAmlFields.swift
@@ -155,8 +155,8 @@ public enum KYCNaturalPersonFieldsEnum: Sendable {
                 return (KYCNaturalPersonFieldKey.taxId, value.data(using: .utf8)!)
             case .taxIdName(let value):
                 return (KYCNaturalPersonFieldKey.taxIdName, value.data(using: .utf8)!)
-            case .occupation(var value):
-                return (KYCNaturalPersonFieldKey.occupation, Data(bytes: &value, count: MemoryLayout.size(ofValue: value)))
+            case .occupation(let value):
+                return (KYCNaturalPersonFieldKey.occupation, String(value).data(using: .utf8)!)
             case .employerName(let value):
                 return (KYCNaturalPersonFieldKey.employerName, value.data(using: .utf8)!)
             case .employerAddress(let value):
@@ -360,8 +360,8 @@ public enum KYCOrganizationFieldsEnum: Sendable {
                 return (KYCOrganizationFieldKey.registrationDate, value.data(using: .utf8)!)
             case .registeredAddress(let value):
                 return (KYCOrganizationFieldKey.registeredAddress, value.data(using: .utf8)!)
-            case .numberOfShareholders(var value):
-                return (KYCOrganizationFieldKey.numberOfShareholders, Data(bytes: &value, count: MemoryLayout.size(ofValue: value)))
+            case .numberOfShareholders(let value):
+                return (KYCOrganizationFieldKey.numberOfShareholders, String(value).data(using: .utf8)!)
             case .shareholderName(let value):
                 return (KYCOrganizationFieldKey.shareholderName, value.data(using: .utf8)!)
             case .photoIncorporationDoc(let value):

--- a/stellarsdk/stellarsdk/transfer_server_protocol/TransferServerService.swift
+++ b/stellarsdk/stellarsdk/transfer_server_protocol/TransferServerService.swift
@@ -481,7 +481,7 @@ public final class TransferServerService: @unchecked Sendable {
     /// - Parameter request: Fee request containing operation type, asset code, and transaction amount
     /// - Returns: AnchorFeeResponseEnum with calculated fee details for the specified operation, or an error
     public func fee(request: FeeRequest) async -> AnchorFeeResponseEnum {
-        var requestPath = "/fee?operation=\(request.operation.urlQueryValueEncoded)&asset_code=\(request.assetCode.urlQueryValueEncoded)&amount=\(String(request.amount).urlQueryValueEncoded)"
+        var requestPath = "/fee?operation=\(request.operation.urlQueryValueEncoded)&asset_code=\(request.assetCode.urlQueryValueEncoded)&amount=\(SepRequestAmount.format(request.amount).urlQueryValueEncoded)"
 
         if let type = request.type {
             requestPath += "&type=\(type.urlQueryValueEncoded)"

--- a/stellarsdk/stellarsdk/utils/SepRequestAmount.swift
+++ b/stellarsdk/stellarsdk/utils/SepRequestAmount.swift
@@ -1,0 +1,48 @@
+//
+//  SepRequestAmount.swift
+//  stellarsdk
+//
+//  Copyright © Soneso. All rights reserved.
+//
+
+import Foundation
+
+/// Renders an asset amount for a SEP request field.
+///
+/// Scoped to the classic seven decimal places, and to request fields the SDK types as a `Double`.
+/// Not for Soroban token amounts, whose scale the token defines and which routinely carry far more
+/// than seven decimals, and not for transaction amounts, which reach operation XDR through
+/// `Operation.toXDRAmount`.
+internal enum SepRequestAmount {
+
+    /// Renders an amount as a plain decimal string suitable for a request parameter.
+    ///
+    /// Never uses scientific notation, which `String(Double)` switches to outside roughly
+    /// 1e-4..1e16 and which anchors do not accept. Stellar assets carry at most seven decimal
+    /// places, so the fraction is rounded to seven digits, trailing zeroes in the fractional
+    /// part are trimmed and the decimal point is suppressed for whole amounts.
+    ///
+    /// The rendering is locale independent: digits are ASCII and the separator is always a
+    /// period, whatever the device's regional settings are.
+    ///
+    /// Three limits are worth knowing. An amount below half a stroop rounds to `0` and the sign
+    /// is dropped, and a non-finite amount renders as the empty string; neither names an amount
+    /// the caller can transact, and both leave the anchor to answer. From 2^29 (536870912) upward
+    /// a `Double` no longer carries seven meaningful fractional digits, because that is where one
+    /// unit in the last place first exceeds a stroop, so the last digits describe the stored value
+    /// rather than the amount that was written.
+    static func format(_ amount: Double) -> String {
+        guard amount.isFinite else {
+            return ""
+        }
+        // A nil locale keeps the conversion ASCII with a period separator.
+        var formatted = String(format: "%.7f", locale: nil, amount)
+        while formatted.hasSuffix("0") {
+            formatted.removeLast()
+        }
+        if formatted.hasSuffix(".") {
+            formatted.removeLast()
+        }
+        return formatted == "-0" ? "0" : formatted
+    }
+}

--- a/stellarsdk/stellarsdk/utils/SepRequestAmount.swift
+++ b/stellarsdk/stellarsdk/utils/SepRequestAmount.swift
@@ -17,32 +17,100 @@ internal enum SepRequestAmount {
 
     /// Renders an amount as a plain decimal string suitable for a request parameter.
     ///
-    /// Never uses scientific notation, which `String(Double)` switches to outside roughly
-    /// 1e-4..1e16 and which anchors do not accept. Stellar assets carry at most seven decimal
-    /// places, so the fraction is rounded to seven digits, trailing zeroes in the fractional
-    /// part are trimmed and the decimal point is suppressed for whole amounts.
+    /// The rendering starts from the shortest decimal representation that reads back to the same
+    /// `Double` — the digits `String(Double)` shows — and rounds it to at most seven decimal
+    /// places, trimming trailing fractional zeroes and suppressing the decimal point for whole
+    /// amounts. It never uses scientific notation, which `String(Double)` switches to outside
+    /// roughly 1e-4..1e16 and which anchors do not accept, and it never renders the binary
+    /// expansion behind the shortest representation. A fraction that ends exactly halfway
+    /// rounds away from zero.
     ///
-    /// The rendering is locale independent: digits are ASCII and the separator is always a
-    /// period, whatever the device's regional settings are.
+    /// The rendering is locale independent: every step is decimal string arithmetic on
+    /// `String(Double)`, whose digits are ASCII with a period separator whatever the device's
+    /// regional settings are.
     ///
-    /// Three limits are worth knowing. An amount below half a stroop rounds to `0` and the sign
-    /// is dropped, and a non-finite amount renders as the empty string; neither names an amount
-    /// the caller can transact, and both leave the anchor to answer. From 2^29 (536870912) upward
-    /// a `Double` no longer carries seven meaningful fractional digits, because that is where one
-    /// unit in the last place first exceeds a stroop, so the last digits describe the stored value
-    /// rather than the amount that was written.
+    /// Two limits are worth knowing. An amount below half a stroop rounds to `0` and the sign is
+    /// dropped, and a non-finite amount renders as the empty string; neither names an amount the
+    /// caller can transact, and both leave the anchor to answer.
     static func format(_ amount: Double) -> String {
         guard amount.isFinite else {
             return ""
         }
-        // A nil locale keeps the conversion ASCII with a period separator.
-        var formatted = String(format: "%.7f", locale: nil, amount)
-        while formatted.hasSuffix("0") {
-            formatted.removeLast()
+
+        var shortest = String(amount)
+        var sign = ""
+        if shortest.hasPrefix("-") {
+            sign = "-"
+            shortest.removeFirst()
         }
-        if formatted.hasSuffix(".") {
-            formatted.removeLast()
+
+        // Split the representation into its digit string and the position of the decimal
+        // point within it, folding a scientific exponent into that position.
+        var exponent = 0
+        if let eIndex = shortest.firstIndex(where: { $0 == "e" || $0 == "E" }) {
+            exponent = Int(shortest[shortest.index(after: eIndex)...]) ?? 0
+            shortest = String(shortest[..<eIndex])
         }
-        return formatted == "-0" ? "0" : formatted
+        var pointPosition: Int
+        if let dotIndex = shortest.firstIndex(of: ".") {
+            pointPosition = shortest.distance(from: shortest.startIndex, to: dotIndex)
+            shortest.remove(at: dotIndex)
+        } else {
+            pointPosition = shortest.count
+        }
+        let digits = shortest
+        pointPosition += exponent
+
+        var integerDigits: String
+        var fractionDigits: String
+        if pointPosition <= 0 {
+            integerDigits = "0"
+            fractionDigits = String(repeating: "0", count: -pointPosition) + digits
+        } else if pointPosition >= digits.count {
+            integerDigits = digits + String(repeating: "0", count: pointPosition - digits.count)
+            fractionDigits = ""
+        } else {
+            let splitIndex = digits.index(digits.startIndex, offsetBy: pointPosition)
+            integerDigits = String(digits[..<splitIndex])
+            fractionDigits = String(digits[splitIndex...])
+        }
+
+        // Round the fraction to seven places on the decimal digits, carrying into the
+        // integer part when the fraction overflows.
+        if fractionDigits.count > 7 {
+            let cutIndex = fractionDigits.index(fractionDigits.startIndex, offsetBy: 7)
+            let roundsUp = fractionDigits[cutIndex] >= "5"
+            fractionDigits = String(fractionDigits[..<cutIndex])
+            if roundsUp {
+                var combined = Array(integerDigits + fractionDigits)
+                var index = combined.count - 1
+                var carry = true
+                while carry && index >= 0 {
+                    if combined[index] == "9" {
+                        combined[index] = "0"
+                    } else {
+                        combined[index] = Character(String(combined[index].wholeNumberValue! + 1))
+                        carry = false
+                    }
+                    index -= 1
+                }
+                if carry {
+                    combined.insert("1", at: 0)
+                }
+                fractionDigits = String(combined.suffix(7))
+                integerDigits = String(combined.prefix(combined.count - 7))
+            }
+        }
+
+        while fractionDigits.hasSuffix("0") {
+            fractionDigits.removeLast()
+        }
+        let body = fractionDigits.isEmpty ? integerDigits : integerDigits + "." + fractionDigits
+
+        // A zero result carries no sign.
+        if body.allSatisfy({ $0 == "0" || $0 == "." }) {
+            return "0"
+        }
+        return sign + body
     }
 }

--- a/stellarsdk/stellarsdk/xdr_helpers/LedgerEntryDataXDR+Helpers.swift
+++ b/stellarsdk/stellarsdk/xdr_helpers/LedgerEntryDataXDR+Helpers.swift
@@ -6,10 +6,6 @@ extension LedgerEntryDataXDR {
         self = try LedgerEntryDataXDR(from: xdrDecoder)
     }
 
-    public var isBool: Bool {
-        return type() == SCValType.bool.rawValue
-    }
-
     public var account: AccountEntryXDR? {
         switch self {
         case .account(let val):

--- a/stellarsdk/stellarsdkIntegrationTests/docs/Sep09DocTest.swift
+++ b/stellarsdk/stellarsdkIntegrationTests/docs/Sep09DocTest.swift
@@ -178,10 +178,12 @@ class Sep09DocTest: XCTestCase {
     }
 
     func testNaturalPersonOccupationParameter() {
-        // occupation takes an Int
+        // occupation takes an Int and is sent as its decimal representation
         let field = KYCNaturalPersonFieldsEnum.occupation(2511)
-        let (key, _) = field.parameter
+        let (key, data) = field.parameter
         XCTAssertEqual(key, "occupation")
+        XCTAssertEqual(String(data: data, encoding: .utf8), "2511")
+        XCTAssertEqual(data.count, 4)
     }
 
     func testNaturalPersonBinaryFieldsParameter() {
@@ -254,10 +256,12 @@ class Sep09DocTest: XCTestCase {
     }
 
     func testOrganizationNumberOfShareholdersParameter() {
-        // numberOfShareholders takes an Int
+        // numberOfShareholders takes an Int and is sent as its decimal representation
         let field = KYCOrganizationFieldsEnum.numberOfShareholders(3)
-        let (key, _) = field.parameter
+        let (key, data) = field.parameter
         XCTAssertEqual(key, "organization.number_of_shareholders")
+        XCTAssertEqual(String(data: data, encoding: .utf8), "3")
+        XCTAssertEqual(data.count, 1)
     }
 
     func testOrganizationBinaryFieldsParameter() {

--- a/stellarsdk/stellarsdkUnitTests/sep/interactive/InteractiveServiceTestCase.swift
+++ b/stellarsdk/stellarsdkUnitTests/sep/interactive/InteractiveServiceTestCase.swift
@@ -834,6 +834,7 @@ class InteractiveServiceTestCase: XCTestCase {
         let params = req.toParameters()
 
         XCTAssertNotNil(params["occupation"])
+        XCTAssertEqual("1234", String(data: params["occupation"]!, encoding: .utf8))
     }
 
     func testDepositRequestWithOrganizationNumberOfShareholders() {
@@ -846,6 +847,7 @@ class InteractiveServiceTestCase: XCTestCase {
         let params = req.toParameters()
 
         XCTAssertNotNil(params["organization.number_of_shareholders"])
+        XCTAssertEqual("5", String(data: params["organization.number_of_shareholders"]!, encoding: .utf8))
     }
 
     // MARK: - Service Initialization Tests

--- a/stellarsdk/stellarsdkUnitTests/sep/interactive/Sep24FeeAmountQueryTestCase.swift
+++ b/stellarsdk/stellarsdkUnitTests/sep/interactive/Sep24FeeAmountQueryTestCase.swift
@@ -56,6 +56,16 @@ class Sep24FeeAmountQueryTestCase: XCTestCase {
         assertNoExponent(in: query)
     }
 
+    func testLargeAmountKeepsTheWrittenDecimals() async {
+        // The stored Double is 100000000000.100006103515625; the query must carry the
+        // shortest representation, not the binary expansion behind it.
+        let request = Sep24FeeRequest(operation: "deposit", assetCode: "USD", amount: 100_000_000_000.1)
+        let query = await feeQuery(for: request)
+
+        XCTAssertEqual("100000000000.1", amountValue(in: query))
+        assertNoExponent(in: query)
+    }
+
     func testWholeAmountIsSentWithoutADecimalPoint() async {
         let request = Sep24FeeRequest(operation: "deposit", assetCode: "USD", amount: 10.0)
         let query = await feeQuery(for: request)

--- a/stellarsdk/stellarsdkUnitTests/sep/interactive/Sep24FeeAmountQueryTestCase.swift
+++ b/stellarsdk/stellarsdkUnitTests/sep/interactive/Sep24FeeAmountQueryTestCase.swift
@@ -1,0 +1,109 @@
+//
+//  Sep24FeeAmountQueryTestCase.swift
+//  stellarsdkTests
+//
+//  Copyright © Soneso. All rights reserved.
+//
+
+import XCTest
+import stellarsdk
+
+/// Verifies that the amount of a SEP-24 fee request reaches the anchor as a plain
+/// decimal, never in scientific notation.
+class Sep24FeeAmountQueryTestCase: XCTestCase {
+
+    let interactiveServer = "127.0.0.1"
+
+    var interactiveService: InteractiveService!
+
+    override func setUp() {
+        super.setUp()
+
+        URLProtocol.registerClass(ServerMock.self)
+        ServerMock.removeAll()
+        interactiveService = InteractiveService(serviceAddress: "http://\(interactiveServer)")
+    }
+
+    override func tearDown() {
+        ServerMock.removeAll()
+        super.tearDown()
+    }
+
+    func testSmallAmountIsSentAsPlainDecimal() async {
+        // 123 stroops, an ordinary amount, which String(Double) spells "1.23e-05".
+        let request = Sep24FeeRequest(operation: "deposit", assetCode: "USD", amount: 0.0000123)
+        let query = await feeQuery(for: request)
+
+        XCTAssertEqual("0.0000123", amountValue(in: query))
+        assertNoExponent(in: query)
+        XCTAssertEqual(true, query?.contains("amount=0.0000123"), query ?? "no query captured")
+    }
+
+    func testOneStroopIsSentAsPlainDecimal() async {
+        let request = Sep24FeeRequest(operation: "withdraw", assetCode: "USD", amount: 0.0000001)
+        let query = await feeQuery(for: request)
+
+        XCTAssertEqual("0.0000001", amountValue(in: query))
+        assertNoExponent(in: query)
+    }
+
+    func testLargeAmountIsSentAsPlainDecimal() async {
+        // String(Double) spells this "1e+21".
+        let request = Sep24FeeRequest(operation: "deposit", type: "SEPA", assetCode: "USD", amount: 1e21)
+        let query = await feeQuery(for: request)
+
+        XCTAssertEqual("1000000000000000000000", amountValue(in: query))
+        assertNoExponent(in: query)
+    }
+
+    func testWholeAmountIsSentWithoutADecimalPoint() async {
+        let request = Sep24FeeRequest(operation: "deposit", assetCode: "USD", amount: 10.0)
+        let query = await feeQuery(for: request)
+
+        XCTAssertEqual("10", amountValue(in: query))
+    }
+
+    // MARK: - Helpers
+
+    /// Runs a fee request against a mock that captures the outgoing query string.
+    private func feeQuery(for request: Sep24FeeRequest) async -> String? {
+        var capturedQuery: String?
+        let mock = RequestMock(host: interactiveServer,
+                               path: "/fee",
+                               httpMethod: "GET",
+                               mockHandler: { mock, urlRequest in
+                                   capturedQuery = urlRequest.url?.query
+                                   mock.statusCode = 200
+                                   return "{ \"fee\": 0.013 }"
+                               })
+        ServerMock.add(mock: mock)
+        defer { ServerMock.remove(mock: mock) }
+
+        let responseEnum = await interactiveService.fee(request: request)
+        switch responseEnum {
+        case .success(_):
+            break
+        case .failure(let error):
+            XCTFail(error.localizedDescription)
+        }
+        XCTAssertNotNil(capturedQuery, "the fee request did not reach the mock")
+        return capturedQuery
+    }
+
+    private func amountValue(in query: String?) -> String? {
+        guard let query = query,
+              let components = URLComponents(string: "http://\(interactiveServer)/fee?\(query)") else {
+            return nil
+        }
+        return components.queryItems?.first(where: { $0.name == "amount" })?.value
+    }
+
+    private func assertNoExponent(in query: String?, file: StaticString = #filePath, line: UInt = #line) {
+        guard let amount = amountValue(in: query) else {
+            XCTFail("no amount in query \(query ?? "nil")", file: file, line: line)
+            return
+        }
+        XCTAssertFalse(amount.contains("e"), "exponent in amount \(amount)", file: file, line: line)
+        XCTAssertFalse(amount.contains("E"), "exponent in amount \(amount)", file: file, line: line)
+    }
+}

--- a/stellarsdk/stellarsdkUnitTests/sep/kyc/KycAmlFieldsUnitTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/sep/kyc/KycAmlFieldsUnitTests.swift
@@ -160,7 +160,8 @@ final class KycAmlFieldsUnitTests: XCTestCase {
         let (key, data) = field.parameter
 
         XCTAssertEqual(key, "occupation")
-        XCTAssertGreaterThan(data.count, 0)
+        XCTAssertEqual(String(data: data, encoding: .utf8), "2310")
+        XCTAssertEqual(data.count, 4)
     }
 
     func testNaturalPersonEmployerName() {
@@ -467,7 +468,8 @@ final class KycAmlFieldsUnitTests: XCTestCase {
         let (key, data) = field.parameter
 
         XCTAssertEqual(key, "organization.number_of_shareholders")
-        XCTAssertGreaterThan(data.count, 0)
+        XCTAssertEqual(String(data: data, encoding: .utf8), "5")
+        XCTAssertEqual(data.count, 1)
     }
 
     func testOrganizationShareholderName() {
@@ -712,7 +714,8 @@ final class KycAmlFieldsUnitTests: XCTestCase {
         let (key, data) = field.parameter
 
         XCTAssertEqual(key, "occupation")
-        XCTAssertGreaterThan(data.count, 0)
+        XCTAssertEqual(String(data: data, encoding: .utf8), "0")
+        XCTAssertEqual(data.count, 1)
     }
 
     func testNegativeOccupationCode() {
@@ -720,7 +723,17 @@ final class KycAmlFieldsUnitTests: XCTestCase {
         let (key, data) = field.parameter
 
         XCTAssertEqual(key, "occupation")
-        XCTAssertGreaterThan(data.count, 0)
+        XCTAssertEqual(String(data: data, encoding: .utf8), "-1")
+        XCTAssertEqual(data.count, 2)
+    }
+
+    func testLargeOccupationCode() {
+        let field = KYCNaturalPersonFieldsEnum.occupation(999999)
+        let (key, data) = field.parameter
+
+        XCTAssertEqual(key, "occupation")
+        XCTAssertEqual(String(data: data, encoding: .utf8), "999999")
+        XCTAssertEqual(data.count, 6)
     }
 
     func testZeroNumberOfShareholders() {
@@ -728,7 +741,8 @@ final class KycAmlFieldsUnitTests: XCTestCase {
         let (key, data) = field.parameter
 
         XCTAssertEqual(key, "organization.number_of_shareholders")
-        XCTAssertGreaterThan(data.count, 0)
+        XCTAssertEqual(String(data: data, encoding: .utf8), "0")
+        XCTAssertEqual(data.count, 1)
     }
 
     func testEmailWithSpecialCharacters() {

--- a/stellarsdk/stellarsdkUnitTests/sep/transfer_server_protocol/FeeAmountQueryUnitTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/sep/transfer_server_protocol/FeeAmountQueryUnitTests.swift
@@ -1,0 +1,109 @@
+//
+//  FeeAmountQueryUnitTests.swift
+//  stellarsdkTests
+//
+//  Copyright © Soneso. All rights reserved.
+//
+
+import XCTest
+import stellarsdk
+
+/// Verifies that the amount of a SEP-6 fee request reaches the anchor as a plain
+/// decimal, never in scientific notation.
+class FeeAmountQueryUnitTests: XCTestCase {
+
+    let transferServer = "127.0.0.1"
+
+    var transferServerService: TransferServerService!
+
+    override func setUp() {
+        super.setUp()
+
+        URLProtocol.registerClass(ServerMock.self)
+        ServerMock.removeAll()
+        transferServerService = TransferServerService(serviceAddress: "http://\(transferServer)")
+    }
+
+    override func tearDown() {
+        ServerMock.removeAll()
+        super.tearDown()
+    }
+
+    func testSmallAmountIsSentAsPlainDecimal() async {
+        // 123 stroops, an ordinary amount, which String(Double) spells "1.23e-05".
+        let request = FeeRequest(operation: "deposit", assetCode: "USD", amount: 0.0000123)
+        let query = await feeQuery(for: request)
+
+        XCTAssertEqual("0.0000123", amountValue(in: query))
+        assertNoExponent(in: query)
+        XCTAssertEqual(true, query?.contains("amount=0.0000123"), query ?? "no query captured")
+    }
+
+    func testOneStroopIsSentAsPlainDecimal() async {
+        let request = FeeRequest(operation: "withdraw", assetCode: "USD", amount: 0.0000001)
+        let query = await feeQuery(for: request)
+
+        XCTAssertEqual("0.0000001", amountValue(in: query))
+        assertNoExponent(in: query)
+    }
+
+    func testLargeAmountIsSentAsPlainDecimal() async {
+        // String(Double) spells this "1e+21".
+        let request = FeeRequest(operation: "deposit", type: "SEPA", assetCode: "USD", amount: 1e21)
+        let query = await feeQuery(for: request)
+
+        XCTAssertEqual("1000000000000000000000", amountValue(in: query))
+        assertNoExponent(in: query)
+    }
+
+    func testWholeAmountIsSentWithoutADecimalPoint() async {
+        let request = FeeRequest(operation: "deposit", assetCode: "USD", amount: 120.0)
+        let query = await feeQuery(for: request)
+
+        XCTAssertEqual("120", amountValue(in: query))
+    }
+
+    // MARK: - Helpers
+
+    /// Runs a fee request against a mock that captures the outgoing query string.
+    private func feeQuery(for request: FeeRequest) async -> String? {
+        var capturedQuery: String?
+        let mock = RequestMock(host: transferServer,
+                               path: "/fee",
+                               httpMethod: "GET",
+                               mockHandler: { mock, urlRequest in
+                                   capturedQuery = urlRequest.url?.query
+                                   mock.statusCode = 200
+                                   return "{ \"fee\": 0.013 }"
+                               })
+        ServerMock.add(mock: mock)
+        defer { ServerMock.remove(mock: mock) }
+
+        let responseEnum = await transferServerService.fee(request: request)
+        switch responseEnum {
+        case .success(_):
+            break
+        case .failure(let error):
+            XCTFail(error.localizedDescription)
+        }
+        XCTAssertNotNil(capturedQuery, "the fee request did not reach the mock")
+        return capturedQuery
+    }
+
+    private func amountValue(in query: String?) -> String? {
+        guard let query = query,
+              let components = URLComponents(string: "http://\(transferServer)/fee?\(query)") else {
+            return nil
+        }
+        return components.queryItems?.first(where: { $0.name == "amount" })?.value
+    }
+
+    private func assertNoExponent(in query: String?, file: StaticString = #filePath, line: UInt = #line) {
+        guard let amount = amountValue(in: query) else {
+            XCTFail("no amount in query \(query ?? "nil")", file: file, line: line)
+            return
+        }
+        XCTAssertFalse(amount.contains("e"), "exponent in amount \(amount)", file: file, line: line)
+        XCTAssertFalse(amount.contains("E"), "exponent in amount \(amount)", file: file, line: line)
+    }
+}

--- a/stellarsdk/stellarsdkUnitTests/sep/transfer_server_protocol/FeeAmountQueryUnitTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/sep/transfer_server_protocol/FeeAmountQueryUnitTests.swift
@@ -56,6 +56,16 @@ class FeeAmountQueryUnitTests: XCTestCase {
         assertNoExponent(in: query)
     }
 
+    func testLargeAmountKeepsTheWrittenDecimals() async {
+        // The stored Double is 100000000000.100006103515625; the query must carry the
+        // shortest representation, not the binary expansion behind it.
+        let request = FeeRequest(operation: "deposit", assetCode: "USD", amount: 100_000_000_000.1)
+        let query = await feeQuery(for: request)
+
+        XCTAssertEqual("100000000000.1", amountValue(in: query))
+        assertNoExponent(in: query)
+    }
+
     func testWholeAmountIsSentWithoutADecimalPoint() async {
         let request = FeeRequest(operation: "deposit", assetCode: "USD", amount: 120.0)
         let query = await feeQuery(for: request)

--- a/stellarsdk/stellarsdkUnitTests/utils/SepRequestAmountUnitTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/utils/SepRequestAmountUnitTests.swift
@@ -40,6 +40,14 @@ final class SepRequestAmountUnitTests: XCTestCase {
         XCTAssertEqual("1000000000000000000000", SepRequestAmount.format(1e21))
     }
 
+    func testLargeAmountKeepsTheWrittenDecimals() {
+        // The stored Double is 100000000000.100006103515625; the shortest representation is
+        // the written value, and no digit beyond it may be rendered.
+        XCTAssertEqual("100000000000.1", SepRequestAmount.format(100_000_000_000.1))
+        XCTAssertEqual("-100000000000.1", SepRequestAmount.format(-100_000_000_000.1))
+        XCTAssertEqual("600000000.1", SepRequestAmount.format(600_000_000.1))
+    }
+
     // MARK: - Rounding to seven decimal places
 
     func testMoreThanSevenDecimalsRoundsToSeven() {
@@ -47,15 +55,24 @@ final class SepRequestAmountUnitTests: XCTestCase {
     }
 
     func testSeventhDigitIsRoundedNotTruncated() {
-        // The Double here is 780615714.94290959835052490234375, so rendering more digits and
-        // cutting at the seventh yields ...9429095 while rounding yields ...9429096.
+        // The shortest representation carries exactly seven fractional digits here and is
+        // rendered unchanged.
         XCTAssertEqual("780615714.9429096", SepRequestAmount.format(780615714.9429096))
     }
 
-    func testHalfStroopTieFollowsTheStoredValue() {
-        // The Double nearest 1.5e-7 is 0.000000149999999999999993, so the nearer seven-decimal
-        // value is one stroop, not two.
-        XCTAssertEqual("0.0000001", SepRequestAmount.format(1.5e-7))
+    func testHalfwayFractionRoundsAwayFromZero() {
+        // The written value 0.00000015 ends exactly halfway at the seventh place.
+        XCTAssertEqual("0.0000002", SepRequestAmount.format(1.5e-7))
+        XCTAssertEqual("-0.0000002", SepRequestAmount.format(-1.5e-7))
+        // Half a stroop exactly is halfway at the zero boundary and rounds away,
+        // keeping its sign.
+        XCTAssertEqual("0.0000001", SepRequestAmount.format(5e-8))
+        XCTAssertEqual("-0.0000001", SepRequestAmount.format(-5e-8))
+    }
+
+    func testRoundingCarriesThroughTheIntegerPart() {
+        XCTAssertEqual("1", SepRequestAmount.format(0.99999995))
+        XCTAssertEqual("2", SepRequestAmount.format(1.99999996))
     }
 
     func testBelowHalfAStroopRoundsToZero() {
@@ -102,19 +119,15 @@ final class SepRequestAmountUnitTests: XCTestCase {
     /// The rendering must not follow the device's regional settings, which would otherwise
     /// supply a comma separator or non-ASCII digits.
     ///
-    /// The first assertion pins what a regional setting does to this format string; the ones
-    /// after it catch a rendering that consults the device. They discriminate on any machine
-    /// whose region format is not period-separated, which includes a language identifier
-    /// carrying a regional override such as `en_US@rg=eszzzz` - the configuration that
-    /// surfaces this in the field. Where the region is period-separated throughout they
-    /// render the same either way, so that case rests on the explicit `locale: nil`.
+    /// The rendering is decimal string arithmetic on `String(Double)`, which never consults
+    /// the device, so these assertions pin the ASCII-and-period character set on every
+    /// machine, including one whose language identifier carries a regional override such as
+    /// `en_US@rg=eszzzz` - the configuration that surfaces locale-dependent formatting in
+    /// the field.
     func testRenderingDoesNotFollowTheDeviceLocale() {
-        XCTAssertEqual("0,0000123",
-                       String(format: "%.7f", locale: Locale(identifier: "de_DE"), 0.0000123))
-        XCTAssertEqual("0.0000123", SepRequestAmount.format(0.0000123))
-
         let allowed = Set("0123456789.-")
-        let amounts: [Double] = [0.0000123, 1e21, -0.0000123, 1e16, 0.0000001]
+        let amounts: [Double] = [0.0000123, 1e21, -0.0000123, 1e16, 0.0000001,
+                                 100_000_000_000.1, 1.5e-7]
         for amount in amounts {
             let rendered = SepRequestAmount.format(amount)
             XCTAssertTrue(rendered.allSatisfy { allowed.contains($0) },

--- a/stellarsdk/stellarsdkUnitTests/utils/SepRequestAmountUnitTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/utils/SepRequestAmountUnitTests.swift
@@ -1,0 +1,124 @@
+//
+//  SepRequestAmountUnitTests.swift
+//  stellarsdkUnitTests
+//
+//  Copyright © Soneso. All rights reserved.
+//
+
+import XCTest
+@testable import stellarsdk
+
+final class SepRequestAmountUnitTests: XCTestCase {
+
+    // MARK: - Plain decimal rendering
+
+    func testSmallAmountRendersPlainDecimal() {
+        // 123 stroops, an ordinary amount. String(Double) spells it "1.23e-05".
+        XCTAssertEqual("0.0000123", SepRequestAmount.format(0.0000123))
+    }
+
+    func testOneStroopRendersAllSevenDecimals() {
+        XCTAssertEqual("0.0000001", SepRequestAmount.format(0.0000001))
+    }
+
+    func testWholeAmountSuppressesDecimalPoint() {
+        XCTAssertEqual("100", SepRequestAmount.format(100.0))
+        XCTAssertEqual("1", SepRequestAmount.format(1.0))
+        // The trim stops at the decimal point, so zeroes in the integer part survive.
+        XCTAssertEqual("120", SepRequestAmount.format(120.0))
+        XCTAssertEqual("1000000000000000", SepRequestAmount.format(1e15))
+    }
+
+    func testTrailingZeroesInFractionAreTrimmed() {
+        XCTAssertEqual("0.000012", SepRequestAmount.format(0.0000120))
+        XCTAssertEqual("0.00001", SepRequestAmount.format(0.0000100))
+    }
+
+    func testLargeAmountRendersPlainDecimal() {
+        // String(Double) spells these "1e+16" and "1e+21".
+        XCTAssertEqual("10000000000000000", SepRequestAmount.format(1e16))
+        XCTAssertEqual("1000000000000000000000", SepRequestAmount.format(1e21))
+    }
+
+    // MARK: - Rounding to seven decimal places
+
+    func testMoreThanSevenDecimalsRoundsToSeven() {
+        XCTAssertEqual("1.2345679", SepRequestAmount.format(1.23456789))
+    }
+
+    func testSeventhDigitIsRoundedNotTruncated() {
+        // The Double here is 780615714.94290959835052490234375, so rendering more digits and
+        // cutting at the seventh yields ...9429095 while rounding yields ...9429096.
+        XCTAssertEqual("780615714.9429096", SepRequestAmount.format(780615714.9429096))
+    }
+
+    func testHalfStroopTieFollowsTheStoredValue() {
+        // The Double nearest 1.5e-7 is 0.000000149999999999999993, so the nearer seven-decimal
+        // value is one stroop, not two.
+        XCTAssertEqual("0.0000001", SepRequestAmount.format(1.5e-7))
+    }
+
+    func testBelowHalfAStroopRoundsToZero() {
+        XCTAssertEqual("0", SepRequestAmount.format(0.00000004))
+        XCTAssertEqual("0", SepRequestAmount.format(1e-10))
+    }
+
+    // MARK: - Sign
+
+    func testNegativeAmountKeepsItsSign() {
+        XCTAssertEqual("-0.0000123", SepRequestAmount.format(-0.0000123))
+        XCTAssertEqual("-1000000000000000000000", SepRequestAmount.format(-1e21))
+    }
+
+    func testZeroRendersWithoutSign() {
+        XCTAssertEqual("0", SepRequestAmount.format(0.0))
+        XCTAssertEqual("0", SepRequestAmount.format(-0.0))
+        // An amount below half a stroop rounds away, and zero carries no sign.
+        XCTAssertEqual("0", SepRequestAmount.format(-0.00000001))
+    }
+
+    // MARK: - Non-finite amounts
+
+    func testNonFiniteAmountRendersEmpty() {
+        XCTAssertEqual("", SepRequestAmount.format(.nan))
+        XCTAssertEqual("", SepRequestAmount.format(.signalingNaN))
+        XCTAssertEqual("", SepRequestAmount.format(.infinity))
+        XCTAssertEqual("", SepRequestAmount.format(-.infinity))
+    }
+
+    // MARK: - Invariants
+
+    func testNoFiniteAmountRendersAnExponent() {
+        let amounts: [Double] = [0.0000001, 0.0000123, 1e-10, 1e16, 1e21, 1e60,
+                                 .greatestFiniteMagnitude, .leastNormalMagnitude,
+                                 -1e21, -0.0000123]
+        for amount in amounts {
+            let rendered = SepRequestAmount.format(amount)
+            XCTAssertFalse(rendered.contains("e"), "exponent in \(rendered)")
+            XCTAssertFalse(rendered.contains("E"), "exponent in \(rendered)")
+        }
+    }
+
+    /// The rendering must not follow the device's regional settings, which would otherwise
+    /// supply a comma separator or non-ASCII digits.
+    ///
+    /// The first assertion pins what a regional setting does to this format string; the ones
+    /// after it catch a rendering that consults the device. They discriminate on any machine
+    /// whose region format is not period-separated, which includes a language identifier
+    /// carrying a regional override such as `en_US@rg=eszzzz` - the configuration that
+    /// surfaces this in the field. Where the region is period-separated throughout they
+    /// render the same either way, so that case rests on the explicit `locale: nil`.
+    func testRenderingDoesNotFollowTheDeviceLocale() {
+        XCTAssertEqual("0,0000123",
+                       String(format: "%.7f", locale: Locale(identifier: "de_DE"), 0.0000123))
+        XCTAssertEqual("0.0000123", SepRequestAmount.format(0.0000123))
+
+        let allowed = Set("0123456789.-")
+        let amounts: [Double] = [0.0000123, 1e21, -0.0000123, 1e16, 0.0000001]
+        for amount in amounts {
+            let rendered = SepRequestAmount.format(amount)
+            XCTAssertTrue(rendered.allSatisfy { allowed.contains($0) },
+                          "unexpected characters in \(rendered)")
+        }
+    }
+}

--- a/stellarsdk/stellarsdkUnitTests/xdr/XDRCoreTypesUnitTests.swift
+++ b/stellarsdk/stellarsdkUnitTests/xdr/XDRCoreTypesUnitTests.swift
@@ -761,7 +761,7 @@ class XDRCoreTypesUnitTests: XCTestCase {
 
     // MARK: - Edge Cases and Additional Coverage
 
-    func testLedgerEntryDataXDRIsBoolProperty() throws {
+    func testLedgerEntryDataXDRArmAccessors() throws {
         let accountIdString = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ"
         let publicKey = try PublicKey(accountId: accountIdString)
         let thresholds = WrappedData4(Data([1, 2, 3, 4]))
@@ -780,10 +780,19 @@ class XDRCoreTypesUnitTests: XCTestCase {
 
         let ledgerData = LedgerEntryDataXDR.account(accountEntry)
 
-        // The isBool property checks if type equals SCValType.bool.rawValue
-        // Since account type is 0 and SCValType.bool.rawValue is also likely 0, this might be true
-        // This tests the isBool property
-        _ = ledgerData.isBool
+        // Each accessor answers only for its own arm.
+        XCTAssertEqual(ledgerData.type(), LedgerEntryType.account.rawValue)
+        XCTAssertEqual(ledgerData.account?.accountID.accountId, accountIdString)
+        XCTAssertEqual(ledgerData.account?.balance, 1000000)
+        XCTAssertNil(ledgerData.trustline)
+        XCTAssertNil(ledgerData.offer)
+        XCTAssertNil(ledgerData.data)
+        XCTAssertNil(ledgerData.claimableBalance)
+        XCTAssertNil(ledgerData.liquidityPool)
+        XCTAssertNil(ledgerData.contractData)
+        XCTAssertNil(ledgerData.contractCode)
+        XCTAssertNil(ledgerData.configSetting)
+        XCTAssertNil(ledgerData.ttl)
     }
 
     func testAccountEntryExtensionV2() throws {


### PR DESCRIPTION
Three maintenance fixes.

- SEP-6 and SEP-24 fee requests send the amount as a plain decimal. The request types carry the amount as a `Double`, and `String(Double)` switches to scientific notation outside roughly 1e-4..1e16, so one stroop went out as `amount=1e-07`. The internal `SepRequestAmount.format` rounds to at most seven decimals, never uses an exponent, trims trailing zeroes and drops the decimal point for whole amounts. The public `Double` API is unchanged.

- SEP-9 `occupation` and `organization.number_of_shareholders` are sent as decimal text. Both multipart fields built their value from the integer's raw memory, sending eight little-endian bytes where the anchor expects decimal ASCII. They now render with `String(value)` like the other text fields, and their tests pin the exact bytes.

- `LedgerEntryDataXDR.isBool` is removed. `LedgerEntryData` has no bool arm; the property compared the ledger entry type against `SCValType.bool.rawValue` and reported true for every account entry. This is an API removal; the property had no meaningful reading.